### PR TITLE
chore: decompose monolithic CLI router (C1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,26 @@
+## Quality Checks
+
+**Always run `pre-commit run --all-files` as the final gate — not `make check`.**
+
+`make check` runs lint + typecheck + radon + bandit + tests, but misses the `ruff format` hook that pre-commit enforces. When `ruff format` auto-fixes files and returns non-zero, the commit is blocked. Running `make check` alone gives a false green.
+
+### Correct workflow
+
+```
+# After making code changes:
+uv run pre-commit run --all-files
+
+# If ruff-format modified files, stage them and re-run:
+git add -u
+uv run pre-commit run --all-files   # must pass clean (no files modified)
+```
+
+### Why this matters for refactors touching test files
+
+When renaming mock patch paths (e.g. `obsidian_ai_tools.cli.X` → `obsidian_ai_tools.commands.Y.X`), the new strings are often longer and may push lines past the 100-char limit. `ruff format` will auto-fix them, but `make check` / `ruff check` (lint) will not catch formatting-only violations in all configurations. Always verify with pre-commit.
+
+---
+
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 


### PR DESCRIPTION
## Summary

- Splits `cli.py` (2,371 lines) into a `commands/` package with one file per command group
- `cli.py` is now a 27-line pure router — imports command modules and mounts them onto the Typer app
- Follows the architecture review C1 recommendation from `docs/architecture-review-20260601.html`

## What changed

| New file | Commands |
|---|---|
| `commands/ingest.py` | `ingest` |
| `commands/search.py` | `search` |
| `commands/tags.py` | `list-tags`, `tags` |
| `commands/notes.py` | `digest`, `overview` |
| `commands/preview.py` | `preview`, `reading-list` sub-app |
| `commands/vault.py` | `rebuild-index`, `process-inbox`, `update-rules`, `stats`, `quality`, `follow`, `connect`, `refresh` |
| `commands/serve.py` | `serve`, `version` |

Each module exposes a single `register(app)` function — no globals leak into the router.

## Test plan

- [x] All 512 tests pass
- [x] `pre-commit run --all-files` passes clean (lint, format, typecheck, bandit, radon, pytest)
- [x] `kai --help` shows all 17 commands + `reading-list` sub-group
- [x] Mock patch paths in `test_cli.py`, `test_ingest.py`, `test_ingestion_service.py` updated to target command modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)