### PR TITLE
docs: Quick Start guide and AI-assisted development process (#12, #13)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,97 @@
+# Development Process
+
+`obsidian-ai-tools` was built with significant AI assistance using [Claude Code](https://claude.ai/code). This document explains the workflow, conventions, and lessons learned — both to set honest expectations about the codebase and to serve as a reference for contributors or anyone wanting to replicate the approach.
+
+## How It Was Built
+
+### Workflow overview
+
+Each feature followed a roughly consistent loop:
+
+1. **Define the problem** in a short natural-language prompt: what the command should do, what the inputs and outputs are, and any known edge cases.
+2. **Collaborative design**: Claude Code proposed a module structure and API surface. Revisions happened in conversation before any code was written.
+3. **Implementation**: Claude Code wrote the implementation. The human role was to review, redirect, and catch cases where the AI optimised for correctness-on-paper over usability.
+4. **Tests**: Test cases were generated alongside the implementation, with the assistant identifying the important contract surfaces. Most test stubs were written by the AI; edge-case assertions were often added manually after running the suite.
+5. **Quality gates**: Every commit passes ruff, mypy, bandit, gitleaks, radon complexity checks, and the test suite. These were enforced as pre-commit hooks from the start.
+
+### Prompting strategy
+
+- **Start narrow.** Prompts worked best when they described one command or one module at a time. Asking for "the whole ingestion pipeline" in one shot produced overly coupled code.
+- **Describe outputs, not steps.** "Write a function that returns a list of notes sorted by backlink count" outperforms "first load the index, then sort, then..." as input.
+- **Name the constraints upfront.** Mentioning Pydantic models, the existing vault path convention, or the Typer CLI surface at the start of a prompt saved several revision cycles.
+- **Use the `--verbose` flag convention.** All commands accept `--verbose` for debug output; specifying this in prompts kept logging consistent.
+
+### Architecture decisions made collaboratively
+
+- **Typer for the CLI** — chosen over argparse/click for its first-class Pydantic integration and auto-generated `--help`.
+- **Versioned prompt templates** (`prompts/`) — separating prompt content from code meant the AI could improve note quality without touching Python.
+- **DuckDB for observability** — lightweight, no server, queryable from Python with zero setup. Suggested by the AI as an alternative to CSV logs.
+- **Whoosh for search** — pure-Python, embeddable, no external process. Sufficient for personal-vault scale.
+
+### What human review caught
+
+- **Over-abstracting**: The AI frequently introduced helper functions and base classes that were not yet justified. Several abstractions were pruned back.
+- **Silent failures**: Early versions of network calls sometimes caught broad exceptions and returned `None`. Explicit error propagation was enforced manually.
+- **Confusing flag names**: `--confirm` vs `--yes` vs `--no-dry-run` conventions needed one pass of consistency review.
+- **Test coverage gaps**: The AI reliably covered the happy path. Malformed vault paths, missing API keys, and provider-fallback chains required manually written tests.
+
+## Tooling
+
+| Tool | Role |
+|------|------|
+| [Claude Code](https://claude.ai/code) | Primary coding assistant (implementation, tests, refactoring) |
+| [GitNexus](https://gitnexus.dev) | Code-intelligence MCP: impact analysis, call-graph navigation, safe renaming |
+| `CLAUDE.md` | Project-level instructions baked into every Claude Code session |
+| `AGENTS.md` | Conventions for AI agents operating in this repo |
+
+### GitNexus integration
+
+GitNexus indexes the codebase as a knowledge graph. Before modifying any symbol, running `gitnexus_impact` identifies the blast radius (direct callers, affected execution flows, risk level). This prevented several cases where renaming a utility function would have silently broken unrelated commands. See `CLAUDE.md` for the full protocol.
+
+## Key Lessons
+
+### 1. Guardrails prevent slop
+
+AI-assisted development accelerates output dramatically — which means technical debt and low-quality code also accumulate faster without checks. Linting, type checking, complexity limits, security scans, and coverage thresholds all exist here because the first versions of several modules were functionally correct but structurally poor. Adding these gates as pre-commit hooks from the start, not retrofitting them later, was the single most important quality decision.
+
+### 2. Fix root causes, not symptoms
+
+When a check kept failing — a test, a hook, a CI step — the temptation was to patch it locally and move on. This consistently backfired. Updating `AGENTS.md` to record _why_ a check exists, or fixing the underlying convention rather than suppressing the warning, prevented the same failure from re-appearing three PRs later. If something keeps breaking, the answer is in the history and the process, not in the immediate error.
+
+### 3. Avoid becoming a feature factory
+
+AI coding assistants will happily implement whatever you ask, which makes it easy to accumulate features that nobody uses. Product consistency — every command following the same flag conventions, the same output format, the same error behaviour — is harder to maintain than adding new commands. Think hard about whether a new feature actually changes what you do with the tool. Prune commands that duplicate each other or that you have never run on real data.
+
+### 4. Observability is not optional — it is feedback for the AI
+
+Without `kai stats` and `kai quality`, there was no way to know whether the ingestion pipeline was actually working in practice: which providers were failing, which prompts produced low-quality output, what the real cost per note was. Observability here is not just operational hygiene — it is the feedback loop that tells you whether the AI-generated features are delivering value or just passing tests. Concretely:
+
+- **Does it work?** Are ingestion success rates high? Are errors clustered around one provider or one content type?
+- **Am I using it?** A command no one runs is a candidate for removal.
+- **Does it drift?** Do cost-per-note or latency metrics change after a prompt update or model change?
+- **Does it add value?** Are the generated notes actually useful, or are they verbose summaries of content you would have read anyway?
+
+Build observability before you build the next feature.
+
+### Smaller, evergreen lessons
+
+- **Prompt templates as first-class artifacts.** Treating `prompts/` as versioned source (not generated output) made it possible to iterate on note quality independently of the Python code.
+- **AI-generated tests need human adversarial review.** The test suite reached high coverage quickly, but coverage alone does not test the right things. Reviewing test assertions manually before merging a feature was worth the extra 15 minutes.
+- **Conversational context degrades.** Long sessions with many files loaded produced less consistent code than shorter, focused sessions. Breaking work into discrete issues (one feature per branch) improved coherence.
+- **The AI is good at boilerplate, not at taste.** Pydantic models, CLI scaffolding, and CI config came out clean on the first pass. Naming, error messages, and UX decisions needed more iteration.
+
+## Running the Development Suite
+
+```bash
+# Run all quality gates in one shot
+make quality
+
+# Individual gates
+make lint        # ruff
+make typecheck   # mypy
+make radon       # complexity
+make bandit      # security
+make coverage    # pytest + coverage threshold
+```
+
+Pre-commit hooks run a subset on every commit; the full suite runs on push. See `.pre-commit-config.yaml` and `.github/workflows/ci.yml` for the exact configuration.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,39 @@
 - Optional local HTTP service and Chrome extension for browser-based ingestion
 - Cache, circuit-breaker, retry, and rate-limiting support
 
+## Quick Start
+
+Get from zero to your first ingested note in under 10 minutes.
+
+**Prerequisites:** Python 3.11+, git, an [OpenRouter](https://openrouter.ai/) API key, an existing Obsidian vault directory.
+
+```bash
+# 1. Clone and install
+git clone https://github.com/larshansen1/obsidian-ai-tools.git
+cd obsidian-ai-tools
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e .
+
+# 2. Configure
+cp .env.example .env
+# Edit .env — set at minimum:
+#   OPENROUTER_API_KEY=your_key_here
+#   OBSIDIAN_VAULT_PATH=/path/to/your/vault
+
+# 3. Ingest your first URL
+kai ingest "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+```
+
+Expected output:
+
+```
+✓ Fetched transcript (3421 tokens)
+✓ Generated note via anthropic/claude-sonnet-4
+✓ Written to /path/to/your/vault/inbox/Never Gonna Give You Up.md
+```
+
+The note lands in your vault's inbox folder with frontmatter (`title`, `tags`, `source_url`, `model`, `prompt_version`). Run `kai --help` to explore all commands.
+
 ## Requirements
 
 - Python 3.11 or newer
@@ -322,6 +355,8 @@ Several `kai` commands send note content to external LLM APIs:
 Data retention and training opt-out are governed by your OpenRouter account settings and the upstream model provider's privacy policy. By default, OpenRouter does not use submitted data for training — check [OpenRouter's privacy policy](https://openrouter.ai/privacy) and your chosen model provider's policy for the current terms.
 
 The `OPENROUTER_API_KEY` environment variable determines which account (and therefore which data policy) applies.
+
+See [DEVELOPMENT.md](DEVELOPMENT.md) for a detailed account of the AI-assisted development workflow, prompting strategy, and key lessons learned.
 
 ## Security
 


### PR DESCRIPTION
## Summary

- **Quick Start section** added to README — gets a new user from zero to first ingested note in under 10 minutes, covering prerequisites, install, `.env` setup, first command, and expected output (closes #12)
- **DEVELOPMENT.md** created — documents the AI-assisted workflow, prompting strategy, architecture decisions, what human review caught, and four key lessons learned from building this project with Claude Code (closes #13)
- Links DEVELOPMENT.md from the README Development section
- Side-fix: `readme-command-reference` pre-commit hook entry changed from `python` to `.venv/bin/python` (same fix as #17 — `python` is not available on macOS without a symlink)

### Key lessons captured in DEVELOPMENT.md

1. **Guardrails prevent slop** — quality gates from day one keep AI-accelerated output from accumulating debt
2. **Fix root causes, not symptoms** — if a check keeps failing, fix the convention; update AGENTS.md
3. **Avoid becoming a feature factory** — think hard about value, prune what nobody uses
4. **Observability is not optional** — `kai stats` / `kai quality` are the feedback loop that tells you whether AI-generated features actually work in practice

## Test plan

- [ ] README renders correctly on GitHub (Quick Start section is the first thing after Features)
- [ ] DEVELOPMENT.md reads clearly and accurately describes the codebase's actual workflow
- [ ] Pre-commit passes locally

Closes #12
Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)