### PR TITLE
feat: track provider attempts (primary vs fallback) in DuckDB (#22)

### DIFF
--- a/src/obsidian_ai_tools/commands/vault.py
+++ b/src/obsidian_ai_tools/commands/vault.py
@@ -967,3 +967,30 @@ def usage(
         for cmd in known_commands:
             if cmd not in seen:
                 typer.echo(f"{cmd:<24} {'0':>6}  {'—':>8}  {'never':>12}  <- never used")
+
+    provider_rows = get_db().get_provider_summary(days=days)
+    if provider_rows:
+        typer.echo()
+        typer.echo(f"Provider attempts — last {days} day(s)")
+        typer.echo("━" * 60)
+        p_header = f"{'provider':<10} {'strategy':<10} {'attempts':>8}  {'success':>8}"
+        typer.echo(p_header)
+        typer.echo("-" * 60)
+
+        # Calculate fallback rates per provider
+        by_provider: dict[str, dict[str, int]] = {}
+        for row in provider_rows:
+            prov = row["provider"]
+            by_provider.setdefault(prov, {})
+            by_provider[prov][row["strategy"]] = row["attempts"]
+
+        for row in provider_rows:
+            prov = row["provider"]
+            strat = row["strategy"]
+            success_str = f"{row['success_pct']:.0f}%"
+            line = f"{prov:<10} {strat:<10} {row['attempts']:>8}  {success_str:>8}"
+            if strat == "fallback":
+                total = sum(by_provider[prov].values())
+                fallback_rate = row["attempts"] / total * 100 if total else 0
+                line += f"  ({fallback_rate:.0f}% fallback rate)"
+            typer.echo(line)

--- a/src/obsidian_ai_tools/observability.py
+++ b/src/obsidian_ai_tools/observability.py
@@ -84,6 +84,24 @@ class ObservabilityDB:
                 ON command_invocations(timestamp DESC)
             """)
 
+            # Provider attempts table
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS provider_attempts (
+                    timestamp        TIMESTAMP NOT NULL,
+                    provider         VARCHAR   NOT NULL,
+                    strategy         VARCHAR   NOT NULL,
+                    outcome          VARCHAR   NOT NULL,
+                    duration_seconds DECIMAL(8,3),
+                    error_type       VARCHAR,
+                    url              VARCHAR
+                )
+            """)
+
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_prov_timestamp
+                ON provider_attempts(timestamp DESC)
+            """)
+
     def record_cost(
         self,
         operation: str,
@@ -423,6 +441,84 @@ class ObservabilityDB:
                     "calls": int(row[1]),
                     "success_pct": float(row[2]),
                     "last_used": str(row[3])[:10],
+                }
+                for row in rows
+            ]
+
+    def record_provider_attempt(
+        self,
+        provider: str,
+        strategy: str,
+        outcome: str,
+        duration_seconds: float,
+        error_type: str | None = None,
+        url: str | None = None,
+    ) -> None:
+        """Record a single provider attempt (primary or fallback).
+
+        Args:
+            provider: Provider name ("web", "pdf", "youtube", "file")
+            strategy: "primary" or "fallback"
+            outcome: "success" or "failure"
+            duration_seconds: Wall-clock duration of this attempt
+            error_type: Exception class name on failure
+            url: Source URL
+        """
+        try:
+            with duckdb.connect(str(self.db_path)) as conn:
+                conn.execute(
+                    """
+                    INSERT INTO provider_attempts
+                        (timestamp, provider, strategy, outcome,
+                         duration_seconds, error_type, url)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    [
+                        datetime.now(),
+                        provider,
+                        strategy,
+                        outcome,
+                        duration_seconds,
+                        error_type,
+                        url,
+                    ],
+                )
+        except Exception as e:
+            logging.getLogger(__name__).warning(f"Failed to record provider attempt: {e}")
+
+    def get_provider_summary(self, days: int = 30) -> list[dict[str, Any]]:
+        """Return per-provider/strategy attempt counts and success rate.
+
+        Args:
+            days: Look-back window in days
+
+        Returns:
+            List of dicts sorted by provider then strategy.
+        """
+        with duckdb.connect(str(self.db_path)) as conn:
+            rows = conn.execute(
+                """
+                SELECT
+                    provider,
+                    strategy,
+                    COUNT(*) AS attempts,
+                    ROUND(
+                        SUM(CASE WHEN outcome = 'success' THEN 1 ELSE 0 END) * 100.0
+                        / COUNT(*), 1
+                    ) AS success_pct
+                FROM provider_attempts
+                WHERE timestamp > current_timestamp - (? * INTERVAL '1 DAY')
+                GROUP BY provider, strategy
+                ORDER BY provider, strategy
+                """,
+                [days],
+            ).fetchall()
+            return [
+                {
+                    "provider": row[0],
+                    "strategy": row[1],
+                    "attempts": int(row[2]),
+                    "success_pct": float(row[3]),
                 }
                 for row in rows
             ]

--- a/src/obsidian_ai_tools/providers/file.py
+++ b/src/obsidian_ai_tools/providers/file.py
@@ -1,10 +1,12 @@
 """Local file ingestion provider."""
 
 import logging
+import time
 from pathlib import Path
 from typing import Any
 
 from ..models import ArticleMetadata
+from ..observability import get_db
 from .base import BaseProvider
 
 logger = logging.getLogger(__name__)
@@ -41,11 +43,30 @@ class FileProvider(BaseProvider):
         if not path.is_file():
             raise IsADirectoryError(f"Path is a directory: {path}")
 
+        _t0 = time.monotonic()
         try:
             content = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             logger.error(f"Failed to decode file {path} as UTF-8")
+            try:
+                get_db().record_provider_attempt(
+                    "file",
+                    "primary",
+                    "failure",
+                    time.monotonic() - _t0,
+                    "UnicodeDecodeError",
+                    source,
+                )
+            except Exception:  # nosec B110
+                pass
             raise
+
+        try:
+            get_db().record_provider_attempt(
+                "file", "primary", "success", time.monotonic() - _t0, url=source
+            )
+        except Exception:  # nosec B110
+            pass
 
         return ArticleMetadata(
             title=path.stem.replace("_", " ").title(),

--- a/src/obsidian_ai_tools/providers/pdf.py
+++ b/src/obsidian_ai_tools/providers/pdf.py
@@ -2,6 +2,7 @@
 
 import logging
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
@@ -10,6 +11,7 @@ from pypdf import PdfReader
 
 from ..config import get_settings
 from ..models import ArticleMetadata
+from ..observability import get_db
 from ..utils.rate_limiter import RateLimiter
 from .base import BaseProvider
 
@@ -17,6 +19,19 @@ logger = logging.getLogger(__name__)
 
 # Global rate limiter to share state across instances
 _limiter = RateLimiter(delay=2.0)
+
+
+def _record_attempt(
+    strategy: str,
+    outcome: str,
+    duration: float,
+    error_type: str | None = None,
+    url: str | None = None,
+) -> None:
+    try:
+        get_db().record_provider_attempt("pdf", strategy, outcome, duration, error_type, url)
+    except Exception:  # nosec B110
+        pass
 
 
 class PDFProvider(BaseProvider):
@@ -113,7 +128,16 @@ class PDFProvider(BaseProvider):
 
         logger.info(f"Extracting text from local PDF: {path}")
 
-        return self._extract_text_from_pdf(path, max_pages)
+        _t0 = time.monotonic()
+        try:
+            result = self._extract_text_from_pdf(path, max_pages)
+            _record_attempt("primary", "success", time.monotonic() - _t0, url=file_path)
+            return result
+        except Exception as exc:
+            _record_attempt(
+                "primary", "failure", time.monotonic() - _t0, type(exc).__name__, file_path
+            )
+            raise
 
     def _ingest_remote(self, url: str, max_pages: int) -> ArticleMetadata:
         """Extract text from a remote PDF URL.
@@ -129,6 +153,7 @@ class PDFProvider(BaseProvider):
         _limiter.wait(url)
 
         # Try direct download first
+        _t0 = time.monotonic()
         try:
             logger.info(f"Downloading PDF from URL: {url}")
             response = requests.get(url, timeout=30, stream=True)
@@ -158,6 +183,7 @@ class PDFProvider(BaseProvider):
             try:
                 # Extract text from downloaded PDF
                 result = self._extract_text_from_pdf(tmp_path, max_pages, original_url=url)
+                _record_attempt("primary", "success", time.monotonic() - _t0, url=url)
                 return result
             finally:
                 # Clean up temporary file
@@ -165,10 +191,20 @@ class PDFProvider(BaseProvider):
 
         except Exception as e:
             logger.warning(f"Direct PDF download failed: {e}. Attempting fallback.")
+            _record_attempt("primary", "failure", time.monotonic() - _t0, type(e).__name__, url)
 
             # Fall back to Supadata
             if self.supadata_key:
-                return self._fetch_supadata(url)
+                _t1 = time.monotonic()
+                try:
+                    result = self._fetch_supadata(url)
+                    _record_attempt("fallback", "success", time.monotonic() - _t1, url=url)
+                    return result
+                except Exception as exc:
+                    _record_attempt(
+                        "fallback", "failure", time.monotonic() - _t1, type(exc).__name__, url
+                    )
+                    raise
             else:
                 raise RuntimeError(
                     f"Failed to download PDF from {url} and no fallback configured"

--- a/src/obsidian_ai_tools/providers/web.py
+++ b/src/obsidian_ai_tools/providers/web.py
@@ -1,6 +1,7 @@
 """Web content provider implementation using Trafilatura with Supadata fallback."""
 
 import logging
+import time
 from typing import Any
 
 import requests
@@ -9,6 +10,7 @@ from trafilatura.settings import use_config
 
 from ..config import get_settings
 from ..models import ArticleMetadata
+from ..observability import get_db
 from ..utils.rate_limiter import RateLimiter
 from .base import BaseProvider
 
@@ -16,6 +18,20 @@ logger = logging.getLogger(__name__)
 
 # Global rate limiter to share state across instances
 _limiter = RateLimiter(delay=2.0)
+
+
+def _record_attempt(
+    provider: str,
+    strategy: str,
+    outcome: str,
+    duration: float,
+    error_type: str | None = None,
+    url: str | None = None,
+) -> None:
+    try:
+        get_db().record_provider_attempt(provider, strategy, outcome, duration, error_type, url)
+    except Exception:  # nosec B110
+        pass
 
 
 class WebProvider(BaseProvider):
@@ -79,24 +95,37 @@ class WebProvider(BaseProvider):
             return ArticleMetadata(**raw_result)
 
         # 2. Try direct extraction (Trafilatura)
+        _t0 = time.monotonic()
         try:
             result = self._fetch_direct(source)
             if result:
                 logger.info("Successfully fetched article using Trafilatura")
+                _record_attempt("web", "primary", "success", time.monotonic() - _t0, url=source)
                 return ArticleMetadata(**result)
+            _record_attempt("web", "primary", "failure", time.monotonic() - _t0, url=source)
         except Exception as e:
             logger.warning(f"Direct extraction failed: {e}. Attempting fallback.")
+            _record_attempt(
+                "web", "primary", "failure", time.monotonic() - _t0, type(e).__name__, source
+            )
 
         # 3. Fallback to Supadata
         if self.supadata_key:
             logger.info("Falling back to Supadata extraction")
+            _t1 = time.monotonic()
             try:
                 result = self._fetch_supadata(source)
                 if result:
                     logger.info("Successfully fetched article using Supadata")
+                    _record_attempt(
+                        "web", "fallback", "success", time.monotonic() - _t1, url=source
+                    )
                     return ArticleMetadata(**result)
             except Exception as e:
                 logger.error(f"Supadata extraction failed: {e}")
+                _record_attempt(
+                    "web", "fallback", "failure", time.monotonic() - _t1, type(e).__name__, source
+                )
                 raise RuntimeError(f"Failed to fetch article from {source}: {e}") from e
 
         raise RuntimeError(f"Failed to fetch content from {source} and no fallback configured")

--- a/src/obsidian_ai_tools/providers/youtube.py
+++ b/src/obsidian_ai_tools/providers/youtube.py
@@ -1,8 +1,10 @@
 """YouTube content provider."""
 
+import time
 from typing import Any
 
 from ..models import VideoMetadata
+from ..observability import get_db
 from .base import BaseProvider
 
 
@@ -31,4 +33,26 @@ class YouTubeProvider(BaseProvider):
         from ..youtube import YouTubeClient
 
         client = YouTubeClient()
-        return client.get_video_metadata(source, provider_order=kwargs.get("provider_order"))
+        _t0 = time.monotonic()
+        try:
+            result = client.get_video_metadata(source, provider_order=kwargs.get("provider_order"))
+            try:
+                get_db().record_provider_attempt(
+                    "youtube", "primary", "success", time.monotonic() - _t0, url=source
+                )
+            except Exception:  # nosec B110
+                pass
+            return result
+        except Exception as exc:
+            try:
+                get_db().record_provider_attempt(
+                    "youtube",
+                    "primary",
+                    "failure",
+                    time.monotonic() - _t0,
+                    type(exc).__name__,
+                    source,
+                )
+            except Exception:  # nosec B110
+                pass
+            raise

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -194,3 +194,39 @@ def test_track_command_swallows_observability_errors(tmp_path: Path) -> None:
         result = working_cmd()
 
     assert result == "result"
+
+
+def test_provider_attempt_records_round_trip_into_summary(tmp_path: Path) -> None:
+    """record_provider_attempt rows appear in get_provider_summary."""
+    db = ObservabilityDB(tmp_path / "obs.duckdb")
+
+    db.record_provider_attempt("web", "primary", "success", 0.5, url="https://example.com")
+    db.record_provider_attempt("web", "primary", "failure", 0.3, "RuntimeError", "https://x.com")
+    db.record_provider_attempt("web", "fallback", "success", 1.2, url="https://x.com")
+    db.record_provider_attempt("pdf", "primary", "success", 2.0)
+
+    rows = db.get_provider_summary(days=30)
+    by_key = {(r["provider"], r["strategy"]): r for r in rows}
+
+    assert by_key[("web", "primary")]["attempts"] == 2
+    assert by_key[("web", "primary")]["success_pct"] == 50.0
+    assert by_key[("web", "fallback")]["attempts"] == 1
+    assert by_key[("web", "fallback")]["success_pct"] == 100.0
+    assert by_key[("pdf", "primary")]["attempts"] == 1
+
+
+def test_provider_summary_empty_when_no_data(tmp_path: Path) -> None:
+    """get_provider_summary returns an empty list when no data exists."""
+    db = ObservabilityDB(tmp_path / "obs.duckdb")
+    assert db.get_provider_summary() == []
+
+
+def test_provider_attempt_failure_does_not_raise(tmp_path: Path) -> None:
+    """record_provider_attempt swallows DB errors silently."""
+    db = ObservabilityDB(tmp_path / "obs.duckdb")
+
+    with patch(
+        "obsidian_ai_tools.observability.duckdb.connect",
+        side_effect=RuntimeError("locked"),
+    ):
+        db.record_provider_attempt("web", "primary", "success", 0.1)


### PR DESCRIPTION
## Summary

- Adds `provider_attempts` table (timestamp, provider, strategy, outcome, duration_seconds, error_type, url) with migration-safe `CREATE TABLE IF NOT EXISTS`
- `ObservabilityDB.record_provider_attempt()` and `get_provider_summary()` — same silent-failure pattern as existing `record_*` methods
- `web.py`: shared `_record_attempt()` helper instruments primary (Trafilatura) and fallback (Supadata) legs independently
- `pdf.py`: instruments local extract (primary), remote direct download (primary), and Supadata fallback legs independently
- `youtube.py`: records a single primary attempt at the `_ingest()` level (internal transcript provider fallback is opaque to this layer)
- `file.py`: records a single primary attempt, including `UnicodeDecodeError` failure path
- `vault usage` extended with a provider section showing per-strategy attempt counts, success rate, and computed fallback rate
- 3 new tests: round-trip, empty-table, and silent-failure for `record_provider_attempt`

Closes #22. Depends on #20 and #21/#23 (base branch is PR 2).

## Test plan

- [ ] `uv run pre-commit run --all-files` — all hooks pass
- [ ] `COVERAGE=1 ./scripts/test.sh -q` — 583 tests pass, 81% coverage
- [ ] mypy passes on push (pre-push hook)
- [ ] Manual: run `kai ingest <url>`, then `kai usage` — provider section shows web attempt with strategy and outcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)