### PR TITLE
fix: isolate observability DB in tests to prevent production pollution

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,28 @@
 
 import os
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Generator, Iterator
 from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+
+from obsidian_ai_tools.observability import ObservabilityDB, _set_db_for_test
+
+
+@pytest.fixture(autouse=True)
+def _obs_db_tmp(tmp_path: Path) -> Generator[None, None, None]:
+    """Redirect every get_db() call to an isolated per-test DuckDB.
+
+    Without this, track_command / record_provider_attempt write to the
+    real vault database during the test suite, producing bogus counts.
+    Tests that need a specific DB call _set_db_for_test() themselves;
+    this fixture guarantees a clean slate regardless.
+    """
+    db = ObservabilityDB(tmp_path / "obs_test.duckdb")
+    _set_db_for_test(db)
+    yield
+    _set_db_for_test(None)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Problem

`track_command` and `record_provider_attempt` call `get_db()` for every command/provider invocation — including those made by the test suite via Typer's `CliRunner`. `get_db()` lazily initialises from `get_settings()` which is `@lru_cache` and resolves to the real vault path. Result: all ~580 test invocations wrote to the user's production `observability.duckdb`, producing bogus usage counts (81 flashcard "calls" etc.).

## Fix

A single `autouse` fixture in `conftest.py`:

```python
@pytest.fixture(autouse=True)
def _obs_db_tmp(tmp_path: Path) -> Generator[None, None, None]:
    db = ObservabilityDB(tmp_path / "obs_test.duckdb")
    _set_db_for_test(db)
    yield
    _set_db_for_test(None)
```

This runs before every test and injects a fresh, per-test `ObservabilityDB` backed by `tmp_path`. Any `get_db()` call inside the test writes to a throwaway file. Tests in `test_observability.py` that need a real DB call `_set_db_for_test()` themselves and override this cleanly.

## After merging

The existing bogus data in your production DB needs to be cleared:

```python
import duckdb
with duckdb.connect("/path/to/vault/.kai/observability.duckdb") as conn:
    conn.execute("DELETE FROM command_invocations")
    conn.execute("DELETE FROM provider_attempts")
```

Or just `! kai` equivalent (see test plan).

## Test plan

- [ ] `uv run pre-commit run --all-files` passes
- [ ] `COVERAGE=1 ./scripts/test.sh -q` — 574 passed, 82% coverage
- [ ] mypy passes on push
- [ ] After merging: truncate the two tables, run `kai usage` — should show empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)