### PR TITLE
fix: bring command tracking and provider tracking to main (#21-23, #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,9 @@ kai stats --days 7
 kai stats --recent
 kai quality
 kai quality --days 90
+kai usage
+kai usage --days 7
+kai usage --all
 ```
 
 ## Local HTTP Service
@@ -294,6 +297,7 @@ Run `kai COMMAND --help` for all options.
 | `kai tags` | Analyze and fix tag hygiene issues |
 | `kai stats` | Show LLM API cost statistics |
 | `kai quality` | Show ingestion success rates and common errors |
+| `kai usage` | Show command invocation counts and success rates |
 | `kai serve` | Run the local ingestion service |
 | `kai version` | Print the installed version |
 

--- a/src/obsidian_ai_tools/commands/flashcards.py
+++ b/src/obsidian_ai_tools/commands/flashcards.py
@@ -6,12 +6,14 @@ from typing import Annotated
 import typer
 
 from ..config import get_settings
+from ..observability import track_command
 
 
 def register(app: typer.Typer) -> None:
     app.command()(flashcards)
 
 
+@track_command("flashcards")
 def flashcards(
     note_path: Annotated[
         str | None,

--- a/src/obsidian_ai_tools/commands/ingest.py
+++ b/src/obsidian_ai_tools/commands/ingest.py
@@ -17,6 +17,7 @@ from ..ingestion import (
 )
 from ..logging import setup_logging
 from ..models import ArticleMetadata, VideoMetadata
+from ..observability import track_command
 from ..youtube import (
     InvalidYouTubeURLError,
     TranscriptUnavailableError,
@@ -27,6 +28,7 @@ def register(app: typer.Typer) -> None:
     app.command()(ingest)
 
 
+@track_command("ingest")
 def ingest(
     url: Annotated[str, typer.Argument(help="URL or file path to ingest")],
     vault: Annotated[

--- a/src/obsidian_ai_tools/commands/notes.py
+++ b/src/obsidian_ai_tools/commands/notes.py
@@ -6,6 +6,7 @@ from typing import Annotated
 import typer
 
 from ..config import get_settings
+from ..observability import track_command
 
 
 def register(app: typer.Typer) -> None:
@@ -13,6 +14,7 @@ def register(app: typer.Typer) -> None:
     app.command()(overview)
 
 
+@track_command("digest")
 def digest(
     days: Annotated[
         int,
@@ -88,6 +90,7 @@ def digest(
         typer.echo(formatted)
 
 
+@track_command("overview")
 def overview(
     format_type: Annotated[
         str,

--- a/src/obsidian_ai_tools/commands/preview.py
+++ b/src/obsidian_ai_tools/commands/preview.py
@@ -9,6 +9,7 @@ from typing import Annotated
 import typer
 
 from ..config import get_settings
+from ..observability import track_command
 
 # Stored by register() so interactive mode can re-invoke the main app.
 _app: typer.Typer | None = None
@@ -30,6 +31,7 @@ def register(app: typer.Typer) -> None:
     app.command()(preview)
 
 
+@track_command("preview")
 def preview(
     url: Annotated[
         str | None,
@@ -191,6 +193,7 @@ def preview(
             typer.echo(f"   Total estimated cost: ${total_cost:.4f}")
 
 
+@track_command("reading-list list")
 def reading_list_list(
     vault: Annotated[
         Path | None,
@@ -239,6 +242,7 @@ def reading_list_list(
         typer.echo()
 
 
+@track_command("reading-list ingest")
 def reading_list_ingest(
     vault: Annotated[
         Path | None,
@@ -297,6 +301,7 @@ def reading_list_ingest(
     typer.echo(f"✅ Ingested {len(to_ingest)} item(s). {remaining} pending remaining.")
 
 
+@track_command("reading-list clear")
 def reading_list_clear(
     vault: Annotated[
         Path | None,

--- a/src/obsidian_ai_tools/commands/search.py
+++ b/src/obsidian_ai_tools/commands/search.py
@@ -6,12 +6,14 @@ from typing import Annotated
 import typer
 
 from ..config import get_settings
+from ..observability import track_command
 
 
 def register(app: typer.Typer) -> None:
     app.command()(search)
 
 
+@track_command("search")
 def search(
     keyword: Annotated[
         str | None, typer.Option("--keyword", "-k", help="Search for keyword in content")

--- a/src/obsidian_ai_tools/commands/tags.py
+++ b/src/obsidian_ai_tools/commands/tags.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Annotated
 import typer
 
 from ..config import get_settings
+from ..observability import track_command
 
 if TYPE_CHECKING:
     from ..tag_hygiene import TagHygienePlan
@@ -16,6 +17,7 @@ def register(app: typer.Typer) -> None:
     app.command("tags")(tags_command)
 
 
+@track_command("list-tags")
 def list_tags(
     vault: Annotated[
         Path | None,
@@ -67,6 +69,7 @@ def list_tags(
             typer.echo(f"   {tag}: {count} note(s)")
 
 
+@track_command("tags")
 def tags_command(
     confirm: Annotated[
         bool,

--- a/src/obsidian_ai_tools/commands/vault.py
+++ b/src/obsidian_ai_tools/commands/vault.py
@@ -967,3 +967,30 @@ def usage(
         for cmd in known_commands:
             if cmd not in seen:
                 typer.echo(f"{cmd:<24} {'0':>6}  {'—':>8}  {'never':>12}  <- never used")
+
+    provider_rows = get_db().get_provider_summary(days=days)
+    if provider_rows:
+        typer.echo()
+        typer.echo(f"Provider attempts — last {days} day(s)")
+        typer.echo("━" * 60)
+        p_header = f"{'provider':<10} {'strategy':<10} {'attempts':>8}  {'success':>8}"
+        typer.echo(p_header)
+        typer.echo("-" * 60)
+
+        # Calculate fallback rates per provider
+        by_provider: dict[str, dict[str, int]] = {}
+        for row in provider_rows:
+            prov = row["provider"]
+            by_provider.setdefault(prov, {})
+            by_provider[prov][row["strategy"]] = row["attempts"]
+
+        for row in provider_rows:
+            prov = row["provider"]
+            strat = row["strategy"]
+            success_str = f"{row['success_pct']:.0f}%"
+            line = f"{prov:<10} {strat:<10} {row['attempts']:>8}  {success_str:>8}"
+            if strat == "fallback":
+                total = sum(by_provider[prov].values())
+                fallback_rate = row["attempts"] / total * 100 if total else 0
+                line += f"  ({fallback_rate:.0f}% fallback rate)"
+            typer.echo(line)

--- a/src/obsidian_ai_tools/commands/vault.py
+++ b/src/obsidian_ai_tools/commands/vault.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Annotated
 import typer
 
 from ..config import get_settings
+from ..observability import get_db, track_command
 
 if TYPE_CHECKING:
     from ..folder_organizer import NoteToMove, RuleSuggestion
@@ -17,11 +18,13 @@ def register(app: typer.Typer) -> None:
     app.command()(update_rules)
     app.command()(stats)
     app.command()(quality)
+    app.command()(usage)
     app.command()(follow)
     app.command()(connect)
     app.command()(refresh)
 
 
+@track_command("rebuild-index")
 def rebuild_index(
     vault: Annotated[
         Path | None,
@@ -61,6 +64,7 @@ def rebuild_index(
     typer.echo("✅ Index rebuild complete!")
 
 
+@track_command("process-inbox")
 def process_inbox(
     dry_run: Annotated[
         bool,
@@ -172,6 +176,7 @@ def process_inbox(
         typer.echo(f"\n🔍 Dry run complete - {len(notes)} note(s) would be moved")
 
 
+@track_command("update-rules")
 def update_rules(
     confirm: Annotated[
         bool,
@@ -311,6 +316,7 @@ def _display_rule_suggestions(suggestions: list["RuleSuggestion"]) -> None:
         typer.echo()
 
 
+@track_command("stats")
 def stats(
     days: Annotated[
         int,
@@ -337,8 +343,6 @@ def stats(
         kai stats --days 7
         kai stats --recent
     """
-    from ..observability import get_db
-
     try:
         get_settings()
     except Exception as e:
@@ -397,6 +401,7 @@ def stats(
     typer.echo(f"Recent (Last 7 days): ${summary['recent_cost_7days']:.4f}")
 
 
+@track_command("quality")
 def quality(
     days: Annotated[
         int,
@@ -415,8 +420,6 @@ def quality(
         kai quality --days 7
         kai quality --days 90
     """
-    from ..observability import get_db
-
     try:
         get_settings()
     except Exception as e:
@@ -451,6 +454,7 @@ def quality(
             typer.echo(f"  {count}. {error}")
 
 
+@track_command("follow")
 def follow(
     note_title: Annotated[str, typer.Argument(help="Note title or wikilink target to resolve")],
     vault: Annotated[
@@ -498,6 +502,7 @@ def follow(
     typer.echo(content, nl=False)
 
 
+@track_command("connect")
 def connect(
     note: Annotated[
         str | None,
@@ -713,6 +718,7 @@ def connect(
         typer.echo(f"✅ Inserted {len(links)} wikilink(s)")
 
 
+@track_command("refresh")
 def refresh(
     prompt_version: Annotated[
         str,
@@ -879,3 +885,85 @@ def refresh(
             typer.echo(f"   - {error}")
         if len(summary.errors) > 5:
             typer.echo(f"   ... and {len(summary.errors) - 5} more")
+
+
+@track_command("usage")
+def usage(
+    days: Annotated[
+        int,
+        typer.Option("--days", "-d", help="Look-back window in days"),
+    ] = 30,
+    show_all: Annotated[
+        bool,
+        typer.Option("--all", help="Include commands with zero invocations"),
+    ] = False,
+) -> None:
+    """Show command usage statistics.
+
+    Displays how often each command has been invoked, its success rate,
+    and when it was last used. Commands that have never been run are
+    listed as candidates for removal when --all is passed.
+
+    Examples:
+        kai usage
+        kai usage --days 7
+        kai usage --all
+    """
+    try:
+        get_settings()
+    except Exception as e:
+        typer.echo(f"❌ Configuration error: {e}", err=True)
+        raise typer.Exit(1) from e
+
+    rows = get_db().get_invocation_summary(days=days)
+
+    typer.echo(f"Command usage — last {days} day(s)")
+    typer.echo("━" * 60)
+
+    if not rows:
+        typer.echo("No command invocations recorded yet.")
+        if show_all:
+            typer.echo("(All commands shown below have never been run)")
+        else:
+            typer.echo("Run some commands, then check back — or use --all to see all commands.")
+        typer.echo()
+
+    known_commands = [
+        "ingest",
+        "preview",
+        "reading-list list",
+        "reading-list ingest",
+        "reading-list clear",
+        "rebuild-index",
+        "process-inbox",
+        "update-rules",
+        "stats",
+        "quality",
+        "usage",
+        "follow",
+        "connect",
+        "refresh",
+        "digest",
+        "overview",
+        "search",
+        "list-tags",
+        "tags",
+        "flashcards",
+    ]
+
+    seen = {r["command"] for r in rows}
+
+    header = f"{'command':<24} {'calls':>6}  {'success':>8}  {'last used':>12}"
+    typer.echo(header)
+    typer.echo("-" * 60)
+
+    for row in rows:
+        success_str = f"{row['success_pct']:.0f}%"
+        typer.echo(
+            f"{row['command']:<24} {row['calls']:>6}  {success_str:>8}  {row['last_used']:>12}"
+        )
+
+    if show_all:
+        for cmd in known_commands:
+            if cmd not in seen:
+                typer.echo(f"{cmd:<24} {'0':>6}  {'—':>8}  {'never':>12}  <- never used")

--- a/src/obsidian_ai_tools/observability.py
+++ b/src/obsidian_ai_tools/observability.py
@@ -84,6 +84,24 @@ class ObservabilityDB:
                 ON command_invocations(timestamp DESC)
             """)
 
+            # Provider attempts table
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS provider_attempts (
+                    timestamp        TIMESTAMP NOT NULL,
+                    provider         VARCHAR   NOT NULL,
+                    strategy         VARCHAR   NOT NULL,
+                    outcome          VARCHAR   NOT NULL,
+                    duration_seconds DECIMAL(8,3),
+                    error_type       VARCHAR,
+                    url              VARCHAR
+                )
+            """)
+
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_prov_timestamp
+                ON provider_attempts(timestamp DESC)
+            """)
+
     def record_cost(
         self,
         operation: str,
@@ -423,6 +441,84 @@ class ObservabilityDB:
                     "calls": int(row[1]),
                     "success_pct": float(row[2]),
                     "last_used": str(row[3])[:10],
+                }
+                for row in rows
+            ]
+
+    def record_provider_attempt(
+        self,
+        provider: str,
+        strategy: str,
+        outcome: str,
+        duration_seconds: float,
+        error_type: str | None = None,
+        url: str | None = None,
+    ) -> None:
+        """Record a single provider attempt (primary or fallback).
+
+        Args:
+            provider: Provider name ("web", "pdf", "youtube", "file")
+            strategy: "primary" or "fallback"
+            outcome: "success" or "failure"
+            duration_seconds: Wall-clock duration of this attempt
+            error_type: Exception class name on failure
+            url: Source URL
+        """
+        try:
+            with duckdb.connect(str(self.db_path)) as conn:
+                conn.execute(
+                    """
+                    INSERT INTO provider_attempts
+                        (timestamp, provider, strategy, outcome,
+                         duration_seconds, error_type, url)
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    [
+                        datetime.now(),
+                        provider,
+                        strategy,
+                        outcome,
+                        duration_seconds,
+                        error_type,
+                        url,
+                    ],
+                )
+        except Exception as e:
+            logging.getLogger(__name__).warning(f"Failed to record provider attempt: {e}")
+
+    def get_provider_summary(self, days: int = 30) -> list[dict[str, Any]]:
+        """Return per-provider/strategy attempt counts and success rate.
+
+        Args:
+            days: Look-back window in days
+
+        Returns:
+            List of dicts sorted by provider then strategy.
+        """
+        with duckdb.connect(str(self.db_path)) as conn:
+            rows = conn.execute(
+                """
+                SELECT
+                    provider,
+                    strategy,
+                    COUNT(*) AS attempts,
+                    ROUND(
+                        SUM(CASE WHEN outcome = 'success' THEN 1 ELSE 0 END) * 100.0
+                        / COUNT(*), 1
+                    ) AS success_pct
+                FROM provider_attempts
+                WHERE timestamp > current_timestamp - (? * INTERVAL '1 DAY')
+                GROUP BY provider, strategy
+                ORDER BY provider, strategy
+                """,
+                [days],
+            ).fetchall()
+            return [
+                {
+                    "provider": row[0],
+                    "strategy": row[1],
+                    "attempts": int(row[2]),
+                    "success_pct": float(row[3]),
                 }
                 for row in rows
             ]

--- a/src/obsidian_ai_tools/observability.py
+++ b/src/obsidian_ai_tools/observability.py
@@ -1,10 +1,15 @@
 """Observability database management using DuckDB."""
 
+import functools
+import logging
+import time
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import duckdb
+import typer
 
 
 class ObservabilityDB:
@@ -61,6 +66,22 @@ class ObservabilityDB:
             conn.execute("""
                 CREATE INDEX IF NOT EXISTS idx_metrics_timestamp
                 ON metrics(timestamp DESC)
+            """)
+
+            # Command invocations table
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS command_invocations (
+                    timestamp        TIMESTAMP NOT NULL,
+                    command          VARCHAR   NOT NULL,
+                    outcome          VARCHAR   NOT NULL,
+                    duration_seconds DECIMAL(8,3),
+                    error_type       VARCHAR
+                )
+            """)
+
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_cmd_timestamp
+                ON command_invocations(timestamp DESC)
             """)
 
     def record_cost(
@@ -341,6 +362,71 @@ class ObservabilityDB:
                 "common_errors": [(error, int(count)) for error, count in errors],
             }
 
+    def record_invocation(
+        self,
+        command: str,
+        outcome: str,
+        duration_seconds: float,
+        error_type: str | None = None,
+    ) -> None:
+        """Record a CLI command invocation.
+
+        Args:
+            command: Command name (e.g. "ingest", "reading-list ingest")
+            outcome: "success", "error", or "user_abort"
+            duration_seconds: Wall-clock duration
+            error_type: Exception class name when outcome is "error"
+        """
+        try:
+            with duckdb.connect(str(self.db_path)) as conn:
+                conn.execute(
+                    """
+                    INSERT INTO command_invocations
+                        (timestamp, command, outcome, duration_seconds, error_type)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    [datetime.now(), command, outcome, duration_seconds, error_type],
+                )
+        except Exception as e:
+            logging.getLogger(__name__).warning(f"Failed to record invocation: {e}")
+
+    def get_invocation_summary(self, days: int = 30) -> list[dict[str, Any]]:
+        """Return per-command call counts, success rate, and last-used timestamp.
+
+        Args:
+            days: Look-back window in days
+
+        Returns:
+            List of dicts sorted by call count descending.
+        """
+        with duckdb.connect(str(self.db_path)) as conn:
+            rows = conn.execute(
+                """
+                SELECT
+                    command,
+                    COUNT(*) AS calls,
+                    ROUND(
+                        SUM(CASE WHEN outcome = 'success' THEN 1 ELSE 0 END) * 100.0
+                        / COUNT(*), 1
+                    ) AS success_pct,
+                    MAX(timestamp) AS last_used
+                FROM command_invocations
+                WHERE timestamp > current_timestamp - (? * INTERVAL '1 DAY')
+                GROUP BY command
+                ORDER BY calls DESC
+                """,
+                [days],
+            ).fetchall()
+            return [
+                {
+                    "command": row[0],
+                    "calls": int(row[1]),
+                    "success_pct": float(row[2]),
+                    "last_used": str(row[3])[:10],
+                }
+                for row in rows
+            ]
+
 
 _db: Optional["ObservabilityDB"] = None
 
@@ -360,3 +446,42 @@ def _set_db_for_test(db: Optional["ObservabilityDB"]) -> None:
     """Inject or reset the singleton. Test use only."""
     global _db
     _db = db
+
+
+def track_command(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Decorator that records command invocation outcome and duration to ObservabilityDB.
+
+    Apply inside @app.command() so Typer sees the original signature.
+    Observability failures are swallowed and never surface to the user.
+
+    Args:
+        name: Command name as it should appear in the usage report.
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            start = time.monotonic()
+            outcome: str = "success"
+            error_type: str | None = None
+            try:
+                return func(*args, **kwargs)
+            except typer.Exit as exc:
+                if exc.exit_code != 0:
+                    outcome, error_type = "error", "Exit"
+                raise
+            except typer.Abort:
+                outcome = "user_abort"
+                raise
+            except Exception as exc:
+                outcome, error_type = "error", type(exc).__name__
+                raise
+            finally:
+                try:
+                    get_db().record_invocation(name, outcome, time.monotonic() - start, error_type)
+                except Exception:  # nosec B110
+                    pass  # never block the command
+
+        return wrapper
+
+    return decorator

--- a/src/obsidian_ai_tools/providers/file.py
+++ b/src/obsidian_ai_tools/providers/file.py
@@ -1,10 +1,12 @@
 """Local file ingestion provider."""
 
 import logging
+import time
 from pathlib import Path
 from typing import Any
 
 from ..models import ArticleMetadata
+from ..observability import get_db
 from .base import BaseProvider
 
 logger = logging.getLogger(__name__)
@@ -41,11 +43,30 @@ class FileProvider(BaseProvider):
         if not path.is_file():
             raise IsADirectoryError(f"Path is a directory: {path}")
 
+        _t0 = time.monotonic()
         try:
             content = path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             logger.error(f"Failed to decode file {path} as UTF-8")
+            try:
+                get_db().record_provider_attempt(
+                    "file",
+                    "primary",
+                    "failure",
+                    time.monotonic() - _t0,
+                    "UnicodeDecodeError",
+                    source,
+                )
+            except Exception:  # nosec B110
+                pass
             raise
+
+        try:
+            get_db().record_provider_attempt(
+                "file", "primary", "success", time.monotonic() - _t0, url=source
+            )
+        except Exception:  # nosec B110
+            pass
 
         return ArticleMetadata(
             title=path.stem.replace("_", " ").title(),

--- a/src/obsidian_ai_tools/providers/pdf.py
+++ b/src/obsidian_ai_tools/providers/pdf.py
@@ -2,6 +2,7 @@
 
 import logging
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
@@ -10,6 +11,7 @@ from pypdf import PdfReader
 
 from ..config import get_settings
 from ..models import ArticleMetadata
+from ..observability import get_db
 from ..utils.rate_limiter import RateLimiter
 from .base import BaseProvider
 
@@ -17,6 +19,19 @@ logger = logging.getLogger(__name__)
 
 # Global rate limiter to share state across instances
 _limiter = RateLimiter(delay=2.0)
+
+
+def _record_attempt(
+    strategy: str,
+    outcome: str,
+    duration: float,
+    error_type: str | None = None,
+    url: str | None = None,
+) -> None:
+    try:
+        get_db().record_provider_attempt("pdf", strategy, outcome, duration, error_type, url)
+    except Exception:  # nosec B110
+        pass
 
 
 class PDFProvider(BaseProvider):
@@ -113,7 +128,16 @@ class PDFProvider(BaseProvider):
 
         logger.info(f"Extracting text from local PDF: {path}")
 
-        return self._extract_text_from_pdf(path, max_pages)
+        _t0 = time.monotonic()
+        try:
+            result = self._extract_text_from_pdf(path, max_pages)
+            _record_attempt("primary", "success", time.monotonic() - _t0, url=file_path)
+            return result
+        except Exception as exc:
+            _record_attempt(
+                "primary", "failure", time.monotonic() - _t0, type(exc).__name__, file_path
+            )
+            raise
 
     def _ingest_remote(self, url: str, max_pages: int) -> ArticleMetadata:
         """Extract text from a remote PDF URL.
@@ -129,6 +153,7 @@ class PDFProvider(BaseProvider):
         _limiter.wait(url)
 
         # Try direct download first
+        _t0 = time.monotonic()
         try:
             logger.info(f"Downloading PDF from URL: {url}")
             response = requests.get(url, timeout=30, stream=True)
@@ -158,6 +183,7 @@ class PDFProvider(BaseProvider):
             try:
                 # Extract text from downloaded PDF
                 result = self._extract_text_from_pdf(tmp_path, max_pages, original_url=url)
+                _record_attempt("primary", "success", time.monotonic() - _t0, url=url)
                 return result
             finally:
                 # Clean up temporary file
@@ -165,10 +191,20 @@ class PDFProvider(BaseProvider):
 
         except Exception as e:
             logger.warning(f"Direct PDF download failed: {e}. Attempting fallback.")
+            _record_attempt("primary", "failure", time.monotonic() - _t0, type(e).__name__, url)
 
             # Fall back to Supadata
             if self.supadata_key:
-                return self._fetch_supadata(url)
+                _t1 = time.monotonic()
+                try:
+                    result = self._fetch_supadata(url)
+                    _record_attempt("fallback", "success", time.monotonic() - _t1, url=url)
+                    return result
+                except Exception as exc:
+                    _record_attempt(
+                        "fallback", "failure", time.monotonic() - _t1, type(exc).__name__, url
+                    )
+                    raise
             else:
                 raise RuntimeError(
                     f"Failed to download PDF from {url} and no fallback configured"

--- a/src/obsidian_ai_tools/providers/web.py
+++ b/src/obsidian_ai_tools/providers/web.py
@@ -1,6 +1,7 @@
 """Web content provider implementation using Trafilatura with Supadata fallback."""
 
 import logging
+import time
 from typing import Any
 
 import requests
@@ -9,6 +10,7 @@ from trafilatura.settings import use_config
 
 from ..config import get_settings
 from ..models import ArticleMetadata
+from ..observability import get_db
 from ..utils.rate_limiter import RateLimiter
 from .base import BaseProvider
 
@@ -16,6 +18,20 @@ logger = logging.getLogger(__name__)
 
 # Global rate limiter to share state across instances
 _limiter = RateLimiter(delay=2.0)
+
+
+def _record_attempt(
+    provider: str,
+    strategy: str,
+    outcome: str,
+    duration: float,
+    error_type: str | None = None,
+    url: str | None = None,
+) -> None:
+    try:
+        get_db().record_provider_attempt(provider, strategy, outcome, duration, error_type, url)
+    except Exception:  # nosec B110
+        pass
 
 
 class WebProvider(BaseProvider):
@@ -79,24 +95,37 @@ class WebProvider(BaseProvider):
             return ArticleMetadata(**raw_result)
 
         # 2. Try direct extraction (Trafilatura)
+        _t0 = time.monotonic()
         try:
             result = self._fetch_direct(source)
             if result:
                 logger.info("Successfully fetched article using Trafilatura")
+                _record_attempt("web", "primary", "success", time.monotonic() - _t0, url=source)
                 return ArticleMetadata(**result)
+            _record_attempt("web", "primary", "failure", time.monotonic() - _t0, url=source)
         except Exception as e:
             logger.warning(f"Direct extraction failed: {e}. Attempting fallback.")
+            _record_attempt(
+                "web", "primary", "failure", time.monotonic() - _t0, type(e).__name__, source
+            )
 
         # 3. Fallback to Supadata
         if self.supadata_key:
             logger.info("Falling back to Supadata extraction")
+            _t1 = time.monotonic()
             try:
                 result = self._fetch_supadata(source)
                 if result:
                     logger.info("Successfully fetched article using Supadata")
+                    _record_attempt(
+                        "web", "fallback", "success", time.monotonic() - _t1, url=source
+                    )
                     return ArticleMetadata(**result)
             except Exception as e:
                 logger.error(f"Supadata extraction failed: {e}")
+                _record_attempt(
+                    "web", "fallback", "failure", time.monotonic() - _t1, type(e).__name__, source
+                )
                 raise RuntimeError(f"Failed to fetch article from {source}: {e}") from e
 
         raise RuntimeError(f"Failed to fetch content from {source} and no fallback configured")

--- a/src/obsidian_ai_tools/providers/youtube.py
+++ b/src/obsidian_ai_tools/providers/youtube.py
@@ -1,8 +1,10 @@
 """YouTube content provider."""
 
+import time
 from typing import Any
 
 from ..models import VideoMetadata
+from ..observability import get_db
 from .base import BaseProvider
 
 
@@ -31,4 +33,26 @@ class YouTubeProvider(BaseProvider):
         from ..youtube import YouTubeClient
 
         client = YouTubeClient()
-        return client.get_video_metadata(source, provider_order=kwargs.get("provider_order"))
+        _t0 = time.monotonic()
+        try:
+            result = client.get_video_metadata(source, provider_order=kwargs.get("provider_order"))
+            try:
+                get_db().record_provider_attempt(
+                    "youtube", "primary", "success", time.monotonic() - _t0, url=source
+                )
+            except Exception:  # nosec B110
+                pass
+            return result
+        except Exception as exc:
+            try:
+                get_db().record_provider_attempt(
+                    "youtube",
+                    "primary",
+                    "failure",
+                    time.monotonic() - _t0,
+                    type(exc).__name__,
+                    source,
+                )
+            except Exception:  # nosec B110
+                pass
+            raise

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, call, patch
 from typer.testing import CliRunner
 
 from obsidian_ai_tools.cli import app
+from obsidian_ai_tools.observability import _set_db_for_test
 
 runner = CliRunner()
 
@@ -1155,17 +1156,17 @@ def test_stats_recent_no_records(tmp_path: Path) -> None:
 
     dummy_settings = _make_dummy_settings(vault_path)
 
-    with (
-        patch(
+    mock_db = MagicMock()
+    mock_db.get_recent_costs.return_value = []
+    _set_db_for_test(mock_db)
+    try:
+        with patch(
             "obsidian_ai_tools.commands.vault.get_settings",
             return_value=dummy_settings,
-        ),
-        patch("obsidian_ai_tools.observability.get_db") as mock_get_db,
-    ):
-        mock_db = mock_get_db.return_value
-        mock_db.get_recent_costs.return_value = []
-
-        result = runner.invoke(app, ["stats", "--recent"])
+        ):
+            result = runner.invoke(app, ["stats", "--recent"])
+    finally:
+        _set_db_for_test(None)
 
     assert result.exit_code == 0
     assert "No cost records found" in result.output
@@ -1189,17 +1190,17 @@ def test_stats_summary_with_data(tmp_path: Path) -> None:
         "recent_cost_7days": 0.5,
     }
 
-    with (
-        patch(
+    mock_db = MagicMock()
+    mock_db.get_cost_summary.return_value = summary
+    _set_db_for_test(mock_db)
+    try:
+        with patch(
             "obsidian_ai_tools.commands.vault.get_settings",
             return_value=dummy_settings,
-        ),
-        patch("obsidian_ai_tools.observability.get_db") as mock_get_db,
-    ):
-        mock_db = mock_get_db.return_value
-        mock_db.get_cost_summary.return_value = summary
-
-        result = runner.invoke(app, ["stats"])
+        ):
+            result = runner.invoke(app, ["stats"])
+    finally:
+        _set_db_for_test(None)
 
     assert result.exit_code == 0
     assert "Cost Summary" in result.output
@@ -1236,17 +1237,17 @@ def test_quality_summary_with_data(tmp_path: Path) -> None:
         "common_errors": [["TimeoutError", 1]],
     }
 
-    with (
-        patch(
+    mock_db = MagicMock()
+    mock_db.get_quality_summary.return_value = quality_summary
+    _set_db_for_test(mock_db)
+    try:
+        with patch(
             "obsidian_ai_tools.commands.vault.get_settings",
             return_value=dummy_settings,
-        ),
-        patch("obsidian_ai_tools.observability.get_db") as mock_get_db,
-    ):
-        mock_db = mock_get_db.return_value
-        mock_db.get_quality_summary.return_value = quality_summary
-
-        result = runner.invoke(app, ["quality"])
+        ):
+            result = runner.invoke(app, ["quality"])
+    finally:
+        _set_db_for_test(None)
 
     assert result.exit_code == 0
     assert "Quality Metrics" in result.output

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -5,8 +5,14 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import typer
 
-from obsidian_ai_tools.observability import ObservabilityDB, _set_db_for_test, get_db
+from obsidian_ai_tools.observability import (
+    ObservabilityDB,
+    _set_db_for_test,
+    get_db,
+    track_command,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -89,3 +95,102 @@ def test_observability_write_failures_do_not_break_main_operation(tmp_path: Path
     ):
         db.record_cost("ingest", "model", 1, 1, 0.01)
         db.record_metric("web", "failure", 1.0, error_type="network")
+
+
+def test_invocation_records_round_trip_into_summary(tmp_path: Path) -> None:
+    """record_invocation rows appear in get_invocation_summary."""
+    db = ObservabilityDB(tmp_path / "obs.duckdb")
+
+    db.record_invocation("ingest", "success", 1.2)
+    db.record_invocation("ingest", "success", 0.8)
+    db.record_invocation("ingest", "error", 0.5, error_type="ContentFetchError")
+    db.record_invocation("search", "success", 0.3)
+
+    rows = db.get_invocation_summary(days=30)
+    by_command = {r["command"]: r for r in rows}
+
+    assert by_command["ingest"]["calls"] == 3
+    assert by_command["ingest"]["success_pct"] == pytest.approx(66.7, abs=0.1)
+    assert by_command["search"]["calls"] == 1
+    assert by_command["search"]["success_pct"] == 100.0
+
+
+def test_invocation_summary_empty_when_no_data(tmp_path: Path) -> None:
+    """get_invocation_summary returns an empty list when the table is empty."""
+    db = ObservabilityDB(tmp_path / "obs.duckdb")
+    assert db.get_invocation_summary() == []
+
+
+def test_track_command_records_success(tmp_path: Path) -> None:
+    """track_command decorator writes a success row on normal return."""
+    db = ObservabilityDB(tmp_path / "obs.duckdb")
+    _set_db_for_test(db)
+
+    @track_command("test-cmd")
+    def my_cmd() -> str:
+        return "ok"
+
+    my_cmd()
+
+    rows = db.get_invocation_summary(days=1)
+    assert len(rows) == 1
+    assert rows[0]["command"] == "test-cmd"
+    assert rows[0]["calls"] == 1
+    assert rows[0]["success_pct"] == 100.0
+
+
+def test_track_command_records_error_on_exception(tmp_path: Path) -> None:
+    """track_command decorator writes an error row when the command raises."""
+    db = ObservabilityDB(tmp_path / "obs.duckdb")
+    _set_db_for_test(db)
+
+    @track_command("failing-cmd")
+    def bad_cmd() -> None:
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        bad_cmd()
+
+    import duckdb as _duckdb
+
+    with _duckdb.connect(str(tmp_path / "obs.duckdb")) as conn:
+        rows = conn.execute("SELECT outcome, error_type FROM command_invocations").fetchall()
+
+    assert len(rows) == 1
+    assert rows[0][0] == "error"
+    assert rows[0][1] == "ValueError"
+
+
+def test_track_command_records_user_abort(tmp_path: Path) -> None:
+    """track_command decorator writes user_abort when typer.Abort is raised."""
+    db = ObservabilityDB(tmp_path / "obs.duckdb")
+    _set_db_for_test(db)
+
+    @track_command("aborted-cmd")
+    def aborting_cmd() -> None:
+        raise typer.Abort()
+
+    with pytest.raises(typer.Abort):
+        aborting_cmd()
+
+    import duckdb as _duckdb
+
+    with _duckdb.connect(str(tmp_path / "obs.duckdb")) as conn:
+        rows = conn.execute("SELECT outcome FROM command_invocations").fetchall()
+
+    assert rows[0][0] == "user_abort"
+
+
+def test_track_command_swallows_observability_errors(tmp_path: Path) -> None:
+    """track_command never blocks the command when recording fails."""
+    db = ObservabilityDB(tmp_path / "obs.duckdb")
+    _set_db_for_test(db)
+
+    @track_command("cmd")
+    def working_cmd() -> str:
+        return "result"
+
+    with patch.object(db, "record_invocation", side_effect=RuntimeError("db gone")):
+        result = working_cmd()
+
+    assert result == "result"

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -194,3 +194,39 @@ def test_track_command_swallows_observability_errors(tmp_path: Path) -> None:
         result = working_cmd()
 
     assert result == "result"
+
+
+def test_provider_attempt_records_round_trip_into_summary(tmp_path: Path) -> None:
+    """record_provider_attempt rows appear in get_provider_summary."""
+    db = ObservabilityDB(tmp_path / "obs.duckdb")
+
+    db.record_provider_attempt("web", "primary", "success", 0.5, url="https://example.com")
+    db.record_provider_attempt("web", "primary", "failure", 0.3, "RuntimeError", "https://x.com")
+    db.record_provider_attempt("web", "fallback", "success", 1.2, url="https://x.com")
+    db.record_provider_attempt("pdf", "primary", "success", 2.0)
+
+    rows = db.get_provider_summary(days=30)
+    by_key = {(r["provider"], r["strategy"]): r for r in rows}
+
+    assert by_key[("web", "primary")]["attempts"] == 2
+    assert by_key[("web", "primary")]["success_pct"] == 50.0
+    assert by_key[("web", "fallback")]["attempts"] == 1
+    assert by_key[("web", "fallback")]["success_pct"] == 100.0
+    assert by_key[("pdf", "primary")]["attempts"] == 1
+
+
+def test_provider_summary_empty_when_no_data(tmp_path: Path) -> None:
+    """get_provider_summary returns an empty list when no data exists."""
+    db = ObservabilityDB(tmp_path / "obs.duckdb")
+    assert db.get_provider_summary() == []
+
+
+def test_provider_attempt_failure_does_not_raise(tmp_path: Path) -> None:
+    """record_provider_attempt swallows DB errors silently."""
+    db = ObservabilityDB(tmp_path / "obs.duckdb")
+
+    with patch(
+        "obsidian_ai_tools.observability.duckdb.connect",
+        side_effect=RuntimeError("locked"),
+    ):
+        db.record_provider_attempt("web", "primary", "success", 0.1)


### PR DESCRIPTION
## What happened

PRs #25 and #26 were merged into their stacked base branches rather than into `main`. Both branches were already merged into `main` (as PR #24), so the commits from #25 and #26 never landed here.

## What this PR does

Cherry-picks the two missing commits onto `main`:

- `2576c6e` — feat: track CLI command invocations and add vault usage command (#21, #23)
- `f06ca24` — feat: track provider attempts (primary vs fallback) in DuckDB (#22)

No changes to content — identical to the reviewed and approved commits. The test isolation fix from PR #27 was already in `main` and applies cleanly.

## Test plan

- [x] `uv run pre-commit run --all-files` passes
- [x] `COVERAGE=1 ./scripts/test.sh -q` — 583 passed, 81% coverage, all gates pass
- [x] mypy passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)