### PR TITLE
feat: add obsidian:// open link to ingest results

### DIFF
--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -92,6 +92,15 @@
       word-break: break-all;
     }
 
+    .open-link {
+      display: none;
+      margin-top: 8px;
+      color: #89b4fa; font-size: 12px; font-weight: 600;
+      text-decoration: none; cursor: pointer;
+    }
+    .open-link.visible { display: inline-block; }
+    .open-link:hover { text-decoration: underline; }
+
     .tags { margin-top: 8px; display: flex; flex-wrap: wrap; gap: 4px; }
     .tag {
       background: #313244; color: #cba6f7;
@@ -123,6 +132,7 @@
   <div class="result" id="result">
     <div class="result-title" id="result-title"></div>
     <div class="result-detail" id="result-detail"></div>
+    <a class="open-link" id="open-link">Open in Obsidian →</a>
     <div class="tags" id="tags"></div>
   </div>
 

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -73,10 +73,13 @@ function showResult(type, title, detail, tags = [], obsidianUrl = null) {
   openLink.dataset.url = obsidianUrl ?? "";
 }
 
-// Custom-protocol anchors are unreliable inside extension popups, so open
-// obsidian:// via a tab and let the OS protocol handler take over.
+// Custom-protocol anchors are unreliable inside extension popups. Navigating
+// the current tab to obsidian:// triggers the OS protocol handler without
+// actually leaving the page, so no empty tab is left behind.
 openLink.addEventListener("click", () => {
-  if (openLink.dataset.url) chrome.tabs.create({ url: openLink.dataset.url });
+  if (openLink.dataset.url && currentTabId !== null) {
+    chrome.tabs.update(currentTabId, { url: openLink.dataset.url });
+  }
 });
 
 function setLoading(loading) {

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -12,6 +12,7 @@ const resultEl = document.getElementById("result");
 const resultTitle = document.getElementById("result-title");
 const resultDetail = document.getElementById("result-detail");
 const tagsEl = document.getElementById("tags");
+const openLink = document.getElementById("open-link");
 
 let currentUrl = "";
 let currentTabId = null;
@@ -63,12 +64,20 @@ function renderTags(tags) {
   );
 }
 
-function showResult(type, title, detail, tags = []) {
+function showResult(type, title, detail, tags = [], obsidianUrl = null) {
   resultEl.className = `result visible ${type}`;
   resultTitle.textContent = title;
   resultDetail.textContent = detail;
   renderTags(tags);
+  openLink.className = obsidianUrl ? "open-link visible" : "open-link";
+  openLink.dataset.url = obsidianUrl ?? "";
 }
+
+// Custom-protocol anchors are unreliable inside extension popups, so open
+// obsidian:// via a tab and let the OS protocol handler take over.
+openLink.addEventListener("click", () => {
+  if (openLink.dataset.url) chrome.tabs.create({ url: openLink.dataset.url });
+});
 
 function setLoading(loading) {
   btn.disabled = loading;
@@ -93,7 +102,7 @@ btn.addEventListener("click", async () => {
     const data = await r.json();
 
     if (r.ok) {
-      showResult("success", `✓ ${data.title}`, data.file_path, data.tags);
+      showResult("success", `✓ ${data.title}`, data.file_path, data.tags, data.obsidian_url);
     } else {
       showResult("error", "Ingestion failed", data.detail ?? "Unknown error");
     }

--- a/src/obsidian_ai_tools/commands/ingest.py
+++ b/src/obsidian_ai_tools/commands/ingest.py
@@ -18,6 +18,7 @@ from ..ingestion import (
 from ..logging import setup_logging
 from ..models import ArticleMetadata, VideoMetadata
 from ..observability import track_command
+from ..obsidian import build_obsidian_url
 from ..youtube import (
     InvalidYouTubeURLError,
     TranscriptUnavailableError,
@@ -141,7 +142,7 @@ def ingest(
         max_pages=max_pages,
     )
     try:
-        ingest_content(request, settings, on_progress=show_progress)
+        result = ingest_content(request, settings, on_progress=show_progress)
     except ProviderSelectionError:
         typer.echo("❌ Unknown source type. Please provide a valid URL or file path.", err=True)
         raise typer.Exit(1) from None
@@ -169,3 +170,8 @@ def ingest(
         raise typer.Exit(1) from e
 
     typer.echo("✅ Ingestion complete!")
+    vault_path = request.vault_path or settings.obsidian_vault_path
+    try:
+        typer.echo(f"   Open: {build_obsidian_url(vault_path, result.file_path)}")
+    except ValueError:
+        pass

--- a/src/obsidian_ai_tools/commands/search.py
+++ b/src/obsidian_ai_tools/commands/search.py
@@ -7,6 +7,7 @@ import typer
 
 from ..config import get_settings
 from ..observability import track_command
+from ..obsidian import build_obsidian_url
 
 
 def register(app: typer.Typer) -> None:
@@ -120,9 +121,7 @@ def search(
 
     for i, result in enumerate(results, 1):
         note = result.note
-        rel_path = note.file_path.relative_to(vault_path)
-        vault_name = vault_path.name
-        obsidian_url = f"obsidian://open?vault={vault_name}&file={rel_path}"
+        obsidian_url = build_obsidian_url(vault_path, note.file_path)
 
         typer.echo(f"{i}. {note.title}")
         typer.echo(f"   Tags: {', '.join(note.tags) if note.tags else 'none'}")

--- a/src/obsidian_ai_tools/obsidian.py
+++ b/src/obsidian_ai_tools/obsidian.py
@@ -2,6 +2,7 @@
 
 import re
 from pathlib import Path
+from urllib.parse import quote
 
 from .models import Note
 
@@ -67,6 +68,28 @@ def build_filename(source_type: str, title: str) -> str:
     """
     sanitized_title = sanitize_filename(title)
     return f"{source_type}-{sanitized_title}.md"
+
+
+def build_obsidian_url(vault_path: Path, file_path: Path) -> str:
+    """Build an obsidian://open URI for a note inside a vault.
+
+    Assumes the Obsidian vault name matches the vault directory name
+    (Obsidian's default when opening a folder as a vault).
+
+    Args:
+        vault_path: Path to Obsidian vault root
+        file_path: Path to the note file (must be inside vault_path)
+
+    Returns:
+        Percent-encoded obsidian://open URI
+
+    Raises:
+        ValueError: If file_path is not inside vault_path
+    """
+    rel_path = file_path.relative_to(vault_path)
+    vault_name = quote(vault_path.name, safe="")
+    file_param = quote(str(rel_path), safe="")
+    return f"obsidian://open?vault={vault_name}&file={file_param}"
 
 
 def write_note(note: Note, vault_path: Path, inbox_folder: str = "inbox") -> Path:

--- a/src/obsidian_ai_tools/server/app.py
+++ b/src/obsidian_ai_tools/server/app.py
@@ -22,6 +22,7 @@ from ..ingestion import (
 from ..ingestion import (
     IngestionRequest as ServiceIngestionRequest,
 )
+from ..obsidian import build_obsidian_url
 
 # ---------------------------------------------------------------------------
 # Request / response schemas
@@ -44,6 +45,7 @@ class IngestResponse(BaseModel):
     file_path: str
     tags: list[str]
     source_type: str
+    obsidian_url: str | None = None
 
 
 class StatusResponse(BaseModel):
@@ -122,11 +124,18 @@ def create_app() -> FastAPI:
             except Exception:  # nosec B110
                 pass
 
+        vault_path = Path(req.vault_path) if req.vault_path else settings.obsidian_vault_path
+        try:
+            obsidian_url: str | None = build_obsidian_url(vault_path, result.file_path)
+        except ValueError:
+            obsidian_url = None
+
         return IngestResponse(
             title=result.note.title,
             file_path=str(result.file_path),
             tags=result.note.tags,
             source_type=result.note.source_type,
+            obsidian_url=obsidian_url,
         )
 
     return app

--- a/tests/test_ingestion_service.py
+++ b/tests/test_ingestion_service.py
@@ -245,7 +245,11 @@ def test_http_ingest_delegates_to_shared_pipeline(tmp_path: Path) -> None:
         )
 
     assert response.status_code == 200
-    assert response.json()["title"] == note.title
+    body = response.json()
+    assert body["title"] == note.title
+    assert body["obsidian_url"] == (
+        f"obsidian://open?vault={tmp_path.name}&file=inbox%2Fweb-generated-note.md"
+    )
     request = mock_ingest.call_args.args[0]
     assert request == IngestionRequest(
         url=metadata.url,

--- a/tests/test_obsidian.py
+++ b/tests/test_obsidian.py
@@ -8,6 +8,7 @@ import pytest
 from obsidian_ai_tools.models import Note
 from obsidian_ai_tools.obsidian import (
     build_filename,
+    build_obsidian_url,
     sanitize_filename,
     write_note,
 )
@@ -237,3 +238,22 @@ class TestWriteNote:
             pytest.raises(FileWriteError, match="Failed to write note"),
         ):
             write_note(sample_note, temp_vault)
+
+
+class TestBuildObsidianUrl:
+    """Tests for build_obsidian_url function."""
+
+    def test_basic_url(self) -> None:
+        """Test URL for a simple vault and note path."""
+        url = build_obsidian_url(Path("/vaults/notes"), Path("/vaults/notes/inbox/web-note.md"))
+        assert url == "obsidian://open?vault=notes&file=inbox%2Fweb-note.md"
+
+    def test_encodes_special_characters(self) -> None:
+        """Test spaces and ampersands are percent-encoded."""
+        url = build_obsidian_url(Path("/vaults/My Vault"), Path("/vaults/My Vault/inbox/q & a.md"))
+        assert url == "obsidian://open?vault=My%20Vault&file=inbox%2Fq%20%26%20a.md"
+
+    def test_raises_for_file_outside_vault(self) -> None:
+        """Test files outside the vault are rejected."""
+        with pytest.raises(ValueError):
+            build_obsidian_url(Path("/vaults/notes"), Path("/elsewhere/note.md"))


### PR DESCRIPTION
Closes #36

## What

After ingesting a page, both the Chrome extension and the CLI now surface a clickable `obsidian://open?...` link to the created note.

- **Shared helper** `build_obsidian_url()` in `obsidian.py` — percent-encodes vault name and vault-relative path
- **Server**: `POST /ingest` response gains `obsidian_url` field (null if the note lands outside the vault)
- **Extension**: "Open in Obsidian →" link in the success result; opens by navigating the current tab (`chrome.tabs.update`), which triggers the OS protocol handler without leaving the page or leaving an empty tab behind. No new manifest permissions.
- **CLI**: `kai ingest` prints an `Open:` line; `kai search` reuses the helper, fixing its pre-existing URL-encoding bug (spaces/`&` in filenames produced broken links)

## Why obsidian:// (not default md app)

A Chrome extension cannot launch the OS-default markdown editor, and `file://` links would render raw markdown in a tab. The `obsidian://` protocol handler is the only viable path from the browser and matches existing CLI behavior.

## Testing

- 3 new unit tests for `build_obsidian_url` (encoding, outside-vault rejection)
- Server test asserts the encoded `obsidian_url` in the `/ingest` response
- Full suite: 342 passed; ruff/mypy/pre-commit green
- Manually verified end-to-end in Chrome: link opens the note in Obsidian, no leftover tab

Note: assumes Obsidian vault name equals the vault folder name (Obsidian's default; same assumption the CLI already made).

🤖 Generated with [Claude Code](https://claude.com/claude-code)