### PR TITLE
fix(server): restrict /ingest CORS to the Chrome extension origin

### DIFF
--- a/src/obsidian_ai_tools/commands/serve.py
+++ b/src/obsidian_ai_tools/commands/serve.py
@@ -185,6 +185,13 @@ def serve(
 
     from ..server.app import create_app as _create_app
 
+    if host not in ("127.0.0.1", "localhost"):
+        typer.echo(
+            f"⚠️  Binding to {host} exposes the unauthenticated ingest API "
+            "beyond this machine. Use 127.0.0.1 unless you know what you're doing.",
+            err=True,
+        )
+
     typer.echo(f"🚀 kai server starting on http://{host}:{port}")
     typer.echo("   Chrome extension → load chrome-extension/ as an unpacked extension")
     typer.echo("   Press Ctrl+C to stop\n")

--- a/src/obsidian_ai_tools/server/app.py
+++ b/src/obsidian_ai_tools/server/app.py
@@ -68,11 +68,15 @@ def create_app() -> FastAPI:
         docs_url="/docs",
     )
 
-    # Allow requests from the Chrome extension (and localhost dev tools).
-    # The server only binds to 127.0.0.1, so wildcard origins are safe here.
+    # Only the Chrome extension may call this API from a browser context.
+    # A wildcard would let any web page fire drive-by /ingest requests
+    # (CORS restricts browser pages, not network reachability — binding to
+    # 127.0.0.1 does not protect against JS running in the local browser).
+    # Regex instead of an exact ID because unpacked extension IDs differ
+    # per machine. Non-browser clients (curl, scripts) are unaffected.
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origin_regex=r"chrome-extension://.*",
         allow_methods=["GET", "POST"],
         allow_headers=["*"],
     )

--- a/tests/test_ingestion_service.py
+++ b/tests/test_ingestion_service.py
@@ -261,6 +261,34 @@ def test_http_ingest_delegates_to_shared_pipeline(tmp_path: Path) -> None:
     )
 
 
+def test_cors_allows_chrome_extension_origin() -> None:
+    """Test preflight from the extension origin passes CORS."""
+    response = TestClient(create_app()).options(
+        "/ingest",
+        headers={
+            "Origin": "chrome-extension://abcdefghijklmnop",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "chrome-extension://abcdefghijklmnop"
+
+
+def test_cors_rejects_web_origins() -> None:
+    """Test preflight from a regular web page is rejected."""
+    response = TestClient(create_app()).options(
+        "/ingest",
+        headers={
+            "Origin": "https://evil.example.com",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "access-control-allow-origin" not in response.headers
+
+
 def test_cli_ingest_delegates_to_shared_pipeline(tmp_path: Path) -> None:
     """Test the CLI adapter passes options to the shared service."""
     metadata = _metadata()


### PR DESCRIPTION
Closes #38

## What

- Replace `allow_origins=["*"]` with `allow_origin_regex=r"chrome-extension://.*"` on the local ingest server.
- `kai serve` now prints a warning when bound to a non-loopback host (unauthenticated API exposed beyond the machine).

## Why

CORS governs which browser pages may call the API, not network reachability — binding to 127.0.0.1 never protected against JS running in the local browser. Any web page could fire `POST http://127.0.0.1:8765/ingest`; Firefox and Safari lack Private Network Access preflights, so drive-by requests succeed there. Impact: silently burned OpenRouter credits and attacker-controlled notes planted in the vault.

The regex (rather than an exact extension ID) is needed because unpacked extension IDs differ per machine. Non-browser local clients (curl, scripts) are unaffected — CORS is browser-enforced only.

## Testing

- New tests: preflight from `chrome-extension://…` origin passes (200 + echoed allow-origin header); preflight from a web origin is rejected (400, no allow-origin header).
- Full ingestion service suite passes (12 tests); ruff/mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)