### PR TITLE
feat(ingest): support GitHub repo docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,10 @@ MAX_TRANSCRIPT_LENGTH=60000
 # Get from: https://supadata.com/
 # SUPADATA_KEY=your_supadata_api_key_here
 
+# GitHub API (optional - for private repos or higher public repo rate limits)
+# Create a fine-grained token with repository read access.
+# GITHUB_TOKEN=your_github_token_here
+
 # YouTube Transcript Provider Order
 # Comma-separated list of providers to try in order
 # Options: direct (free scraping), supadata (paid API), decodo (paid API)

--- a/prompts/github_repo_v1.md
+++ b/prompts/github_repo_v1.md
@@ -49,8 +49,9 @@ Return ONLY a valid JSON object with this exact structure:
     "Purpose: ...",
     "Principles: ...",
     "Technology: ...",
-    "Usage: ...",
-    "Setup: ..."
+    "Usage Surface: ...",
+    "Setup and Operations: ...",
+    "Caveats: ..."
   ],
   "implications": [
     "Why this repository matters or how it should be used",
@@ -92,5 +93,7 @@ Before returning, verify:
 - Valid JSON format
 - All required fields present
 - Tags are an array of lowercase strings
-- Key points cover purpose, principles, technology, and usage where documented
+- Key points use the section prefixes exactly as shown when evidence exists:
+  `Purpose:`, `Principles:`, `Technology:`, `Usage Surface:`,
+  `Setup and Operations:`, `Caveats:`
 - No unsupported claims about the source code

--- a/prompts/github_repo_v1.md
+++ b/prompts/github_repo_v1.md
@@ -21,17 +21,31 @@ You will receive:
 
 ## Task
 
-Generate a structured note that explains the repository at a high level.
-Focus only on what is supported by the selected documentation.
+Generate a structured note that helps future-me decide whether this repository
+is relevant, trustworthy, and worth using or extending.
+
+Focus on synthesis, not inventory. Do not enumerate every documented feature.
+Group related facts into judgments about architecture, security posture, and
+maturity. Focus only on what is supported by the selected documentation, and
+surface uncertainty when the documentation is thin.
 
 Cover these areas where the documentation provides evidence:
 
 1. **Purpose**: What the project does and who or what it is for
-2. **Principles**: Design philosophy, constraints, assumptions, or project values
-3. **Technology**: Languages, frameworks, dependencies, integrations, runtime needs
-4. **Usage Surface**: CLI commands, APIs, app behavior, workflows, or user-facing tools
-5. **Setup and Operations**: Installation, configuration, authentication, deployment, local dev
-6. **Caveats**: Maintenance status, limitations, security notes, contribution guidance
+2. **Architecture Read**: System shape, major components, integration points,
+   data/control boundaries, and external dependencies
+3. **Design Principles and Tradeoffs**: Design philosophy, constraints,
+   assumptions, explicit tradeoffs, or project values
+4. **Technology and Runtime**: Languages, frameworks, dependencies,
+   integrations, runtime needs, and deployment substrate
+5. **Usage Surface**: CLI commands, APIs, app behavior, workflows, or
+   user-facing tools
+6. **Security Posture**: Auth/authz model, trust boundaries, secrets handling,
+   network exposure, fail-open/fail-closed behavior, and documented gaps
+7. **Operational Maturity**: Setup/deployment story, tests, CI, observability,
+   release/versioning, license, maintenance signals, and maturity classification
+8. **Caveats and Unknowns**: Limitations, missing evidence, maintenance risks,
+   security unknowns, or contribution constraints
 
 ## Output Format
 
@@ -42,24 +56,40 @@ Return ONLY a valid JSON object with this exact structure:
   "title": "Repository name or clear project title",
   "summary": "2-3 sentences explaining the repository purpose and context",
   "claims": [
-    "Specific documented purpose, principle, or project claim",
+    "High-signal documented evidence supporting the architecture/security/maturity read",
     "Only include claims supported by the provided documentation"
   ],
   "key_points": [
     "Purpose: ...",
-    "Principles: ...",
-    "Technology: ...",
+    "Architecture Read: ...",
+    "Design Principles and Tradeoffs: ...",
+    "Technology and Runtime: ...",
     "Usage Surface: ...",
-    "Setup and Operations: ...",
-    "Caveats: ..."
+    "Security Posture: ...",
+    "Operational Maturity: ...",
+    "Caveats and Unknowns: ..."
   ],
   "implications": [
-    "Why this repository matters or how it should be used",
-    "Operational or adoption implications from the docs"
+    "Adoption fit, including who should use it and who should be cautious",
+    "What future-me should verify before relying on or extending it"
   ],
   "tags": ["tag1", "tag2", "tag3"]
 }}
 ```
+
+## Section Guidance
+
+- Write 1 item for `Purpose`.
+- Write 1-3 items for each other `key_points` section.
+- Each item should be a dense synthesis, not a copied feature list.
+- `claims` should contain 3-7 evidence highlights total. Do not include every
+  documented fact.
+- `implications` should contain 2-4 adoption-fit bullets total.
+- Include a maturity classification in `Operational Maturity`, using one of:
+  `prototype`, `early/private`, `usable personal tool`,
+  `production-oriented`, or `mature/reusable`. State the evidence behind it.
+- If security evidence is absent or shallow, say that explicitly in
+  `Security Posture` or `Caveats and Unknowns`; do not invent a security model.
 
 ## Tag Guidelines
 
@@ -86,6 +116,9 @@ when the repository topic is not adequately covered by existing tags.
 - Do not claim the repository uses technology unless the docs or package metadata support it
 - Preserve uncertainty when documentation is incomplete
 - Write for future-you who needs to quickly understand whether this repo is relevant
+- Prefer fewer, denser bullets over many discrete points
+- Judge maturity from evidence, not polish or ambition
+- Security posture should separate documented protections from unknowns
 
 ## Validation
 
@@ -94,6 +127,7 @@ Before returning, verify:
 - All required fields present
 - Tags are an array of lowercase strings
 - Key points use the section prefixes exactly as shown when evidence exists:
-  `Purpose:`, `Principles:`, `Technology:`, `Usage Surface:`,
-  `Setup and Operations:`, `Caveats:`
+  `Purpose:`, `Architecture Read:`, `Design Principles and Tradeoffs:`,
+  `Technology and Runtime:`, `Usage Surface:`, `Security Posture:`,
+  `Operational Maturity:`, `Caveats and Unknowns:`
 - No unsupported claims about the source code

--- a/prompts/github_repo_v1.md
+++ b/prompts/github_repo_v1.md
@@ -1,0 +1,96 @@
+# GitHub Repository Documentation Analysis Prompt (v1)
+
+You are analyzing documentation from a GitHub repository to create a structured
+note for an Obsidian knowledge base.
+
+## Input
+
+You will receive:
+- Repository metadata
+- A bounded set of documentation files selected from the repository
+- Existing tags from the vault (to encourage reuse)
+
+**Repository Information:**
+- Title: {title}
+- URL: {url}
+- Owner: {author}
+- Source: {site_name}
+
+**Selected Documentation Content:**
+{content}
+
+## Task
+
+Generate a structured note that explains the repository at a high level.
+Focus only on what is supported by the selected documentation.
+
+Cover these areas where the documentation provides evidence:
+
+1. **Purpose**: What the project does and who or what it is for
+2. **Principles**: Design philosophy, constraints, assumptions, or project values
+3. **Technology**: Languages, frameworks, dependencies, integrations, runtime needs
+4. **Usage Surface**: CLI commands, APIs, app behavior, workflows, or user-facing tools
+5. **Setup and Operations**: Installation, configuration, authentication, deployment, local dev
+6. **Caveats**: Maintenance status, limitations, security notes, contribution guidance
+
+## Output Format
+
+Return ONLY a valid JSON object with this exact structure:
+
+```json
+{{
+  "title": "Repository name or clear project title",
+  "summary": "2-3 sentences explaining the repository purpose and context",
+  "claims": [
+    "Specific documented purpose, principle, or project claim",
+    "Only include claims supported by the provided documentation"
+  ],
+  "key_points": [
+    "Purpose: ...",
+    "Principles: ...",
+    "Technology: ...",
+    "Usage: ...",
+    "Setup: ..."
+  ],
+  "implications": [
+    "Why this repository matters or how it should be used",
+    "Operational or adoption implications from the docs"
+  ],
+  "tags": ["tag1", "tag2", "tag3"]
+}}
+```
+
+## Tag Guidelines
+
+### Existing Tags (Prefer Reuse)
+
+{EXISTING_TAGS}
+
+**Important**: Prefer reusing existing tags when relevant. Only create new tags
+when the repository topic is not adequately covered by existing tags.
+
+### Tag Format Rules
+
+1. **All lowercase** - Use `ai` not `AI`
+2. **Hyphens for compound words** - Use `github-repo` not `githubrepo`
+3. **Singular form** - Use `tool` not `tools` unless plural is standard
+4. **Short forms preferred**:
+   - `ai` not `artificial-intelligence`
+   - `llm` not `large-language-model`
+   - `cli` not `command-line-interface`
+
+## Quality Requirements
+
+- Do not infer implementation details from file names alone
+- Do not claim the repository uses technology unless the docs or package metadata support it
+- Preserve uncertainty when documentation is incomplete
+- Write for future-you who needs to quickly understand whether this repo is relevant
+
+## Validation
+
+Before returning, verify:
+- Valid JSON format
+- All required fields present
+- Tags are an array of lowercase strings
+- Key points cover purpose, principles, technology, and usage where documented
+- No unsupported claims about the source code

--- a/src/obsidian_ai_tools/config.py
+++ b/src/obsidian_ai_tools/config.py
@@ -67,6 +67,10 @@ class Settings(BaseSettings):
     supadata_key: str | None = Field(
         default=None, description="Supadata API key for YouTube transcripts (optional)"
     )
+    github_token: str | None = Field(
+        default=None,
+        description="GitHub token for private repository documentation ingestion (optional)",
+    )
     youtube_transcript_provider_order: str = Field(
         default="direct,supadata,decodo",
         description="Comma-separated list of transcript providers (direct,supadata,decodo)",

--- a/src/obsidian_ai_tools/ingestion.py
+++ b/src/obsidian_ai_tools/ingestion.py
@@ -108,6 +108,7 @@ def default_prompt_version(provider_name: str) -> str:
     return {
         "youtube": "youtube_v2",
         "file": "markdown_v1",
+        "github": "github_repo_v1",
         "pdf": "pdf_v1",
     }.get(provider_name, "article_v1")
 

--- a/src/obsidian_ai_tools/llm.py
+++ b/src/obsidian_ai_tools/llm.py
@@ -144,10 +144,12 @@ def generate_note(
         content = metadata.transcript
         source_type = "youtube"
         author = metadata.channel_name
+        source_references: list[str] = []
     else:
         content = metadata.content
-        source_type = "web"
+        source_type = metadata.source_type
         author = metadata.author if metadata.author else "Unknown"
+        source_references = metadata.source_references
 
     if len(content) > max_content_length:
         raise NoteGenerationError(
@@ -212,6 +214,7 @@ def generate_note(
             author=author,
             source_url=metadata.url,
             source_type=source_type,
+            source_references=source_references,
             model=model,
             prompt_version=prompt_version,
         )

--- a/src/obsidian_ai_tools/models.py
+++ b/src/obsidian_ai_tools/models.py
@@ -111,6 +111,75 @@ class Note(BaseModel):
             return f'"{escaped}"'
         return value
 
+    def _github_sections(self) -> dict[str, list[str]]:
+        section_aliases = {
+            "purpose": "Purpose",
+            "principles": "Principles",
+            "technology": "Technology",
+            "usage": "Usage Surface",
+            "usage surface": "Usage Surface",
+            "setup": "Setup and Operations",
+            "setup and operations": "Setup and Operations",
+            "caveats": "Caveats",
+        }
+        sections: dict[str, list[str]] = {}
+        for point in self.key_points:
+            label, separator, detail = point.partition(":")
+            section = section_aliases.get(label.strip().lower()) if separator else None
+            if section is None:
+                sections.setdefault("Additional Notes", []).append(point)
+            elif detail.strip():
+                sections.setdefault(section, []).append(detail.strip())
+        return sections
+
+    def _github_body(self) -> str:
+        body = f"""# {self.title}
+
+## Summary
+
+{self.summary}
+
+"""
+        sections = self._github_sections()
+        section_order = [
+            "Purpose",
+            "Principles",
+            "Technology",
+            "Usage Surface",
+            "Setup and Operations",
+            "Caveats",
+            "Additional Notes",
+        ]
+        for section in section_order:
+            if section not in sections:
+                continue
+            body += f"## {section}\n\n"
+            for item in sections[section]:
+                body += f"- {item}\n"
+            body += "\n"
+
+        if self.claims:
+            body += "## Documented Claims\n\n"
+            for claim in self.claims:
+                body += f"- {claim}\n"
+            body += "\n"
+
+        if self.implications:
+            body += "## Implications\n\n"
+            for impl in self.implications:
+                body += f"- {impl}\n"
+            body += "\n"
+
+        body += f"""## Source
+
+[GitHub Repository]({self.source_url})
+"""
+        if self.source_references:
+            body += "\n## Source Files\n\n"
+            for reference in self.source_references:
+                body += f"- {reference}\n"
+        return body
+
     def to_markdown(self) -> str:
         """Convert note to Obsidian-formatted markdown with frontmatter."""
         # Format tags for frontmatter (list format)
@@ -140,6 +209,9 @@ model: {self.model}
 prompt_version: {self.prompt_version}
 ---
 """
+
+        if self.source_type == "github":
+            return frontmatter + "\n" + self._github_body()
 
         # Build body
         body = f"""# {self.title}

--- a/src/obsidian_ai_tools/models.py
+++ b/src/obsidian_ai_tools/models.py
@@ -114,13 +114,23 @@ class Note(BaseModel):
     def _github_sections(self) -> dict[str, list[str]]:
         section_aliases = {
             "purpose": "Purpose",
+            "architecture": "Architecture Read",
+            "architecture read": "Architecture Read",
             "principles": "Principles",
+            "design principles": "Design Principles and Tradeoffs",
+            "design principles and tradeoffs": "Design Principles and Tradeoffs",
             "technology": "Technology",
+            "technology and runtime": "Technology and Runtime",
             "usage": "Usage Surface",
             "usage surface": "Usage Surface",
             "setup": "Setup and Operations",
             "setup and operations": "Setup and Operations",
+            "security": "Security Posture",
+            "security posture": "Security Posture",
+            "maturity": "Operational Maturity",
+            "operational maturity": "Operational Maturity",
             "caveats": "Caveats",
+            "caveats and unknowns": "Caveats and Unknowns",
         }
         sections: dict[str, list[str]] = {}
         for point in self.key_points:
@@ -143,10 +153,16 @@ class Note(BaseModel):
         sections = self._github_sections()
         section_order = [
             "Purpose",
+            "Architecture Read",
+            "Design Principles and Tradeoffs",
             "Principles",
+            "Technology and Runtime",
             "Technology",
             "Usage Surface",
+            "Security Posture",
+            "Operational Maturity",
             "Setup and Operations",
+            "Caveats and Unknowns",
             "Caveats",
             "Additional Notes",
         ]
@@ -159,13 +175,13 @@ class Note(BaseModel):
             body += "\n"
 
         if self.claims:
-            body += "## Documented Claims\n\n"
+            body += "## Evidence Highlights\n\n"
             for claim in self.claims:
                 body += f"- {claim}\n"
             body += "\n"
 
         if self.implications:
-            body += "## Implications\n\n"
+            body += "## Adoption Fit\n\n"
             for impl in self.implications:
                 body += f"- {impl}\n"
             body += "\n"

--- a/src/obsidian_ai_tools/models.py
+++ b/src/obsidian_ai_tools/models.py
@@ -41,6 +41,11 @@ class ArticleMetadata(BaseModel):
     author: str | None = Field(None, description="Article author")
     site_name: str | None = Field(None, description="Website name")
     published_date: str | None = Field(None, description="Publication date")
+    source_type: str = Field(default="web", description="Content source type")
+    source_references: list[str] = Field(
+        default_factory=list,
+        description="Markdown-formatted source references used to build this content",
+    )
     fetched_at: datetime = Field(
         default_factory=datetime.now,
         description="Timestamp when article was fetched",
@@ -59,6 +64,10 @@ class Note(BaseModel):
     author: str | None = Field(None, description="Content author/creator")
     source_url: str = Field(..., description="Original source URL")
     source_type: str = Field(default="youtube", description="Content source type")
+    source_references: list[str] = Field(
+        default_factory=list,
+        description="Markdown-formatted source references used to build this note",
+    )
     created_at: datetime = Field(
         default_factory=datetime.now, description="Note creation timestamp"
     )
@@ -168,5 +177,9 @@ prompt_version: {self.prompt_version}
 
 [{link_text}]({self.source_url})
 """
+        if self.source_references:
+            body += "\n## Source Files\n\n"
+            for reference in self.source_references:
+                body += f"- {reference}\n"
 
         return frontmatter + "\n" + body

--- a/src/obsidian_ai_tools/providers/factory.py
+++ b/src/obsidian_ai_tools/providers/factory.py
@@ -2,6 +2,7 @@
 
 from .base import BaseProvider
 from .file import FileProvider
+from .github import GitHubProvider
 from .pdf import PDFProvider
 from .web import WebProvider
 from .youtube import YouTubeProvider
@@ -14,6 +15,7 @@ class ProviderFactory:
         YouTubeProvider,
         PDFProvider,  # PDF before File so .pdf files use PDF provider
         FileProvider,
+        GitHubProvider,  # GitHub repo URLs before Web catch-all
         WebProvider,  # Web is catch-all for URLs, so put last
     ]
 

--- a/src/obsidian_ai_tools/providers/github.py
+++ b/src/obsidian_ai_tools/providers/github.py
@@ -1,0 +1,385 @@
+"""GitHub repository documentation ingestion provider."""
+
+import base64
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote, urlparse
+
+import requests
+
+from ..config import get_settings
+from ..models import ArticleMetadata
+from .base import BaseProvider
+
+logger = logging.getLogger(__name__)
+
+GITHUB_API_URL = "https://api.github.com"
+DOCS_DIRECTORIES = {"doc", "docs", "documentation"}
+DOC_EXTENSIONS = {".adoc", ".md", ".markdown", ".mdx", ".rst", ".txt"}
+ROOT_DOC_PREFIXES = (
+    "readme",
+    "contributing",
+    "security",
+    "changelog",
+    "code_of_conduct",
+    "license",
+)
+PACKAGE_METADATA_FILES = {
+    "package.json",
+    "pyproject.toml",
+    "requirements.txt",
+    "setup.py",
+    "cargo.toml",
+    "go.mod",
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+}
+
+
+class GitHubRepositoryError(ValueError):
+    """Raised when a GitHub repository cannot be ingested as documentation."""
+
+
+@dataclass(frozen=True)
+class GitHubRepoRef:
+    owner: str
+    repo: str
+    ref: str | None = None
+    docs_prefix: str | None = None
+
+    @property
+    def display_name(self) -> str:
+        return f"{self.owner}/{self.repo}"
+
+    @property
+    def repository_url(self) -> str:
+        return f"https://github.com/{self.owner}/{self.repo}"
+
+
+@dataclass(frozen=True)
+class DocumentationCandidate:
+    path: str
+    priority: int
+    size: int | None = None
+
+
+@dataclass(frozen=True)
+class DocumentationFile:
+    path: str
+    content: str
+    url: str
+
+    @property
+    def markdown_reference(self) -> str:
+        return f"[{self.path}]({self.url})"
+
+
+def parse_github_repo_url(source: str) -> GitHubRepoRef | None:
+    """Parse supported GitHub repository URLs.
+
+    Blob/raw file URLs intentionally return None so the existing web provider
+    can keep handling single-file GitHub ingestion.
+    """
+    parsed = urlparse(source)
+    if parsed.scheme not in {"http", "https"} or parsed.netloc.lower() != "github.com":
+        return None
+
+    parts = [part for part in parsed.path.strip("/").split("/") if part]
+    if len(parts) < 2:
+        return None
+
+    owner, repo = parts[0], parts[1].removesuffix(".git")
+    if not owner or not repo:
+        return None
+
+    if len(parts) == 2:
+        return GitHubRepoRef(owner=owner, repo=repo)
+
+    route = parts[2].lower()
+    if route == "tree" and len(parts) >= 4:
+        docs_prefix = "/".join(parts[4:]) if len(parts) > 4 else None
+        return GitHubRepoRef(owner=owner, repo=repo, ref=parts[3], docs_prefix=docs_prefix)
+
+    return None
+
+
+class GitHubProvider(BaseProvider):
+    """Provider for summarizing GitHub repositories from documentation files."""
+
+    max_files = 12
+    max_total_chars = 120_000
+    max_file_chars = 40_000
+    max_docs_depth = 3
+    max_directory_entries = 200
+
+    def __init__(self) -> None:
+        self.github_token = self._load_token()
+
+    @property
+    def name(self) -> str:
+        return "github"
+
+    def validate(self, source: str) -> bool:
+        """Check if source is a supported GitHub repository URL."""
+        return parse_github_repo_url(source) is not None
+
+    def _ingest(self, source: str, **kwargs: Any) -> ArticleMetadata:
+        """Fetch bounded repository documentation and return aggregated metadata."""
+        repo = parse_github_repo_url(source)
+        if repo is None:
+            raise GitHubRepositoryError(f"Unsupported GitHub repository URL: {source}")
+
+        ref = repo.ref or self._fetch_default_branch(repo)
+        candidates = self._discover_documentation_candidates(repo, ref)
+        selected = sorted(candidates, key=lambda item: (item.priority, item.path.lower()))[
+            : self.max_files
+        ]
+        if not selected:
+            raise GitHubRepositoryError(
+                f"No documentation files found in {repo.display_name}. "
+                "Expected files like README*, docs/**, CONTRIBUTING*, SECURITY*, "
+                "CHANGELOG*, or package metadata."
+            )
+
+        files = self._fetch_selected_files(repo, ref, selected)
+        if not files:
+            raise GitHubRepositoryError(
+                f"Documentation files in {repo.display_name} were empty or unreadable."
+            )
+
+        content = self._build_content(repo, ref, files)
+        return ArticleMetadata(
+            url=repo.repository_url if repo.ref is None else f"{repo.repository_url}/tree/{ref}",
+            title=f"{repo.display_name} repository documentation",
+            author=repo.owner,
+            site_name="GitHub Repository",
+            published_date=None,
+            content=content,
+            source_type="github",
+            source_references=[file.markdown_reference for file in files],
+        )
+
+    def _load_token(self) -> str | None:
+        try:
+            settings = get_settings()
+            if settings.github_token:
+                return settings.github_token
+        except Exception:
+            logger.debug("GitHub token unavailable from settings", exc_info=True)
+        return os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
+
+    def _headers(self) -> dict[str, str]:
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if self.github_token:
+            headers["Authorization"] = f"Bearer {self.github_token}"
+        return headers
+
+    def _github_get(self, url: str, params: dict[str, str] | None = None) -> Any:
+        response = requests.get(url, headers=self._headers(), params=params, timeout=30)
+        if response.status_code in {401, 403}:
+            message = self._github_error_message(response)
+            raise GitHubRepositoryError(message)
+        if response.status_code == 404:
+            raise GitHubRepositoryError(
+                "GitHub repository or documentation path was not found. "
+                "For private repositories, set GITHUB_TOKEN with repository read access."
+            )
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            raise GitHubRepositoryError(f"GitHub request failed: {exc}") from exc
+        return response.json()
+
+    def _github_error_message(self, response: requests.Response) -> str:
+        remaining = response.headers.get("X-RateLimit-Remaining")
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = {}
+        message = str(payload.get("message") or response.text or "GitHub access denied")
+        if remaining == "0" or "rate limit" in message.lower():
+            return (
+                "GitHub API rate limit exceeded while fetching repository documentation. "
+                "Set GITHUB_TOKEN to use authenticated GitHub API access."
+            )
+        return (
+            "GitHub repository requires access or credentials. "
+            "Set GITHUB_TOKEN with repository read access and try again. "
+            f"GitHub response: {message}"
+        )
+
+    def _fetch_default_branch(self, repo: GitHubRepoRef) -> str:
+        data = self._github_get(f"{GITHUB_API_URL}/repos/{repo.owner}/{repo.repo}")
+        default_branch = data.get("default_branch")
+        if not isinstance(default_branch, str) or not default_branch:
+            raise GitHubRepositoryError(
+                f"Could not determine default branch for {repo.display_name}."
+            )
+        return default_branch
+
+    def _list_directory(
+        self, repo: GitHubRepoRef, ref: str, path: str | None = None
+    ) -> list[dict[str, Any]]:
+        encoded_path = quote(path or "", safe="/")
+        url = f"{GITHUB_API_URL}/repos/{repo.owner}/{repo.repo}/contents"
+        if encoded_path:
+            url = f"{url}/{encoded_path}"
+        data = self._github_get(url, params={"ref": ref})
+        if isinstance(data, dict):
+            data = [data]
+        if not isinstance(data, list):
+            raise GitHubRepositoryError(
+                f"Unexpected GitHub contents response for {repo.display_name}."
+            )
+        return data[: self.max_directory_entries]
+
+    def _discover_documentation_candidates(
+        self, repo: GitHubRepoRef, ref: str
+    ) -> list[DocumentationCandidate]:
+        candidates: list[DocumentationCandidate] = []
+        root_items = self._list_directory(repo, ref, repo.docs_prefix)
+        for item in root_items:
+            path = str(item.get("path") or "")
+            name = str(item.get("name") or "")
+            item_type = item.get("type")
+            if item_type == "file" and repo.docs_prefix is not None and self._is_docs_file(name):
+                candidates.append(
+                    DocumentationCandidate(
+                        path=path,
+                        priority=self._priority_for_path(path),
+                        size=item.get("size"),
+                    )
+                )
+            elif item_type == "file" and self._is_root_documentation_file(name):
+                candidates.append(
+                    DocumentationCandidate(
+                        path=path,
+                        priority=self._priority_for_path(path),
+                        size=item.get("size"),
+                    )
+                )
+            elif item_type == "dir" and (
+                repo.docs_prefix is not None or name.lower() in DOCS_DIRECTORIES
+            ):
+                self._collect_docs_directory(repo, ref, path, 1, candidates)
+        return candidates
+
+    def _collect_docs_directory(
+        self,
+        repo: GitHubRepoRef,
+        ref: str,
+        path: str,
+        depth: int,
+        candidates: list[DocumentationCandidate],
+    ) -> None:
+        if depth > self.max_docs_depth:
+            return
+        for item in self._list_directory(repo, ref, path):
+            item_path = str(item.get("path") or "")
+            item_name = str(item.get("name") or "")
+            item_type = item.get("type")
+            if item_type == "file" and self._is_docs_file(item_name):
+                candidates.append(
+                    DocumentationCandidate(
+                        path=item_path,
+                        priority=self._priority_for_path(item_path),
+                        size=item.get("size"),
+                    )
+                )
+            elif item_type == "dir":
+                self._collect_docs_directory(repo, ref, item_path, depth + 1, candidates)
+
+    def _is_root_documentation_file(self, name: str) -> bool:
+        lower_name = name.lower()
+        if lower_name in PACKAGE_METADATA_FILES:
+            return True
+        stem, _, extension = lower_name.rpartition(".")
+        base_name = stem or lower_name
+        return lower_name.endswith(tuple(DOC_EXTENSIONS)) and base_name.startswith(
+            ROOT_DOC_PREFIXES
+        )
+
+    def _is_docs_file(self, name: str) -> bool:
+        return name.lower().endswith(tuple(DOC_EXTENSIONS))
+
+    def _priority_for_path(self, path: str) -> int:
+        lower_path = path.lower()
+        name = lower_path.rsplit("/", 1)[-1]
+        if name.startswith("readme"):
+            return 0 if "/" not in lower_path else 20
+        if name.startswith("contributing"):
+            return 10
+        if name.startswith("security"):
+            return 11
+        if name.startswith("changelog"):
+            return 12
+        if lower_path.startswith(("docs/", "doc/", "documentation/")):
+            return 30
+        if name in PACKAGE_METADATA_FILES:
+            return 70
+        return 90
+
+    def _fetch_selected_files(
+        self, repo: GitHubRepoRef, ref: str, selected: list[DocumentationCandidate]
+    ) -> list[DocumentationFile]:
+        files: list[DocumentationFile] = []
+        total_chars = 0
+        for candidate in selected:
+            remaining = self.max_total_chars - total_chars
+            if remaining <= 0:
+                break
+            content = self._fetch_file_text(repo, ref, candidate.path)
+            if not content.strip():
+                continue
+            content = content[: min(self.max_file_chars, remaining)]
+            total_chars += len(content)
+            files.append(
+                DocumentationFile(
+                    path=candidate.path,
+                    content=content,
+                    url=f"{repo.repository_url}/blob/{ref}/{candidate.path}",
+                )
+            )
+        return files
+
+    def _fetch_file_text(self, repo: GitHubRepoRef, ref: str, path: str) -> str:
+        encoded_path = quote(path, safe="/")
+        data = self._github_get(
+            f"{GITHUB_API_URL}/repos/{repo.owner}/{repo.repo}/contents/{encoded_path}",
+            params={"ref": ref},
+        )
+        if not isinstance(data, dict) or data.get("type") != "file":
+            raise GitHubRepositoryError(f"GitHub path is not a file: {path}")
+        if data.get("encoding") != "base64" or not isinstance(data.get("content"), str):
+            raise GitHubRepositoryError(
+                f"GitHub file content is not available through the API: {path}"
+            )
+        encoded = data["content"].replace("\n", "")
+        try:
+            return base64.b64decode(encoded).decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise GitHubRepositoryError(
+                f"GitHub documentation file is not UTF-8 text: {path}"
+            ) from exc
+
+    def _build_content(self, repo: GitHubRepoRef, ref: str, files: list[DocumentationFile]) -> str:
+        selected = "\n".join(f"- {file.path}" for file in files)
+        sections = [
+            "# GitHub Repository Documentation",
+            "",
+            f"Repository: {repo.display_name}",
+            f"Reference: {ref}",
+            "",
+            "Selected documentation files:",
+            selected,
+            "",
+        ]
+        for file in files:
+            sections.extend([f"## {file.path}", "", file.content.strip(), ""])
+        return "\n".join(sections).strip()

--- a/src/obsidian_ai_tools/providers/github.py
+++ b/src/obsidian_ai_tools/providers/github.py
@@ -37,6 +37,15 @@ PACKAGE_METADATA_FILES = {
     "build.gradle",
     "build.gradle.kts",
 }
+PRIMARY_README_FILES = {
+    "readme",
+    "readme.adoc",
+    "readme.md",
+    "readme.markdown",
+    "readme.mdx",
+    "readme.rst",
+    "readme.txt",
+}
 
 
 class GitHubRepositoryError(ValueError):
@@ -311,8 +320,10 @@ class GitHubProvider(BaseProvider):
     def _priority_for_path(self, path: str) -> int:
         lower_path = path.lower()
         name = lower_path.rsplit("/", 1)[-1]
-        if name.startswith("readme"):
+        if name in PRIMARY_README_FILES:
             return 0 if "/" not in lower_path else 20
+        if name.startswith("readme"):
+            return 5 if "/" not in lower_path else 25
         if name.startswith("contributing"):
             return 10
         if name.startswith("security"):

--- a/tests/providers/test_github.py
+++ b/tests/providers/test_github.py
@@ -106,6 +106,40 @@ def test_github_provider_ingests_bounded_documentation_with_provenance() -> None
     assert "https://api.github.com/repos/user/repo/contents/src/main.py" not in fetched_urls
 
 
+def test_github_provider_prioritizes_canonical_readme_before_translations() -> None:
+    """The canonical README should be selected before localized README variants."""
+    provider = GitHubProvider()
+    responses = {
+        "https://api.github.com/repos/user/repo": FakeResponse({"default_branch": "main"}),
+        "https://api.github.com/repos/user/repo/contents": FakeResponse(
+            [
+                {"type": "file", "name": "README.zh-CN.md", "path": "README.zh-CN.md"},
+                {"type": "file", "name": "README.md", "path": "README.md"},
+                {"type": "file", "name": "README.ja-JP.md", "path": "README.ja-JP.md"},
+            ]
+        ),
+        "https://api.github.com/repos/user/repo/contents/README.md": FakeResponse(
+            encoded_file("# Canonical README")
+        ),
+        "https://api.github.com/repos/user/repo/contents/README.ja-JP.md": FakeResponse(
+            encoded_file("# Japanese README")
+        ),
+        "https://api.github.com/repos/user/repo/contents/README.zh-CN.md": FakeResponse(
+            encoded_file("# Chinese README")
+        ),
+    }
+
+    def fake_get(url: str, **kwargs: Any) -> FakeResponse:
+        return responses[url]
+
+    with patch("obsidian_ai_tools.providers.github.requests.get", side_effect=fake_get):
+        result = provider._ingest("https://github.com/user/repo")
+
+    assert result.source_references[0] == (
+        "[README.md](https://github.com/user/repo/blob/main/README.md)"
+    )
+
+
 def test_github_provider_treats_tree_docs_url_as_documentation_root() -> None:
     """A /tree/<ref>/docs URL should select docs files from that directory."""
     provider = GitHubProvider()

--- a/tests/providers/test_github.py
+++ b/tests/providers/test_github.py
@@ -1,0 +1,199 @@
+"""Tests for GitHub repository documentation ingestion."""
+
+import base64
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from obsidian_ai_tools.providers.factory import ProviderFactory
+from obsidian_ai_tools.providers.github import GitHubProvider, GitHubRepositoryError
+from obsidian_ai_tools.providers.web import WebProvider
+
+
+class FakeResponse:
+    """Small response double for GitHub API tests."""
+
+    def __init__(
+        self,
+        payload: Any,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+        text: str = "",
+    ) -> None:
+        self._payload = payload
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.text = text
+
+    def json(self) -> Any:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"{self.status_code} error")
+
+
+def encoded_file(content: str) -> dict[str, str]:
+    """Return a GitHub contents API file payload."""
+    encoded = base64.b64encode(content.encode("utf-8")).decode("ascii")
+    return {"type": "file", "encoding": "base64", "content": encoded}
+
+
+def test_github_provider_validates_repo_urls_without_stealing_blob_urls() -> None:
+    """Repo URLs use GitHubProvider, while blob URLs stay with WebProvider."""
+    provider = GitHubProvider()
+
+    assert provider.validate("https://github.com/user/repo")
+    assert provider.validate("https://github.com/user/repo/tree/main/docs")
+    assert not provider.validate("https://github.com/user/repo/blob/main/README.md")
+
+    assert isinstance(ProviderFactory.get_provider("https://github.com/user/repo"), GitHubProvider)
+    blob_provider = ProviderFactory.get_provider("https://github.com/user/repo/blob/main/README.md")
+    assert isinstance(blob_provider, WebProvider)
+
+
+def test_github_provider_ingests_bounded_documentation_with_provenance() -> None:
+    """A repo with README and docs is aggregated from selected documentation only."""
+    provider = GitHubProvider()
+    responses = {
+        "https://api.github.com/repos/user/repo": FakeResponse({"default_branch": "main"}),
+        "https://api.github.com/repos/user/repo/contents": FakeResponse(
+            [
+                {"type": "file", "name": "README.md", "path": "README.md", "size": 100},
+                {"type": "file", "name": "pyproject.toml", "path": "pyproject.toml", "size": 50},
+                {"type": "file", "name": "main.py", "path": "src/main.py", "size": 10},
+                {"type": "dir", "name": "docs", "path": "docs"},
+            ]
+        ),
+        "https://api.github.com/repos/user/repo/contents/docs": FakeResponse(
+            [
+                {"type": "file", "name": "principles.md", "path": "docs/principles.md"},
+                {"type": "file", "name": "logo.png", "path": "docs/logo.png"},
+            ]
+        ),
+        "https://api.github.com/repos/user/repo/contents/README.md": FakeResponse(
+            encoded_file("# Repo\n\nPurpose text.")
+        ),
+        "https://api.github.com/repos/user/repo/contents/docs/principles.md": FakeResponse(
+            encoded_file("# Principles\n\nDocumentation-first source selection.")
+        ),
+        "https://api.github.com/repos/user/repo/contents/pyproject.toml": FakeResponse(
+            encoded_file("[project]\nname = 'repo'")
+        ),
+    }
+    fetched_urls: list[str] = []
+
+    def fake_get(url: str, **kwargs: Any) -> FakeResponse:
+        fetched_urls.append(url)
+        return responses[url]
+
+    with patch("obsidian_ai_tools.providers.github.requests.get", side_effect=fake_get):
+        result = provider._ingest("https://github.com/user/repo")
+
+    assert result.source_type == "github"
+    assert result.url == "https://github.com/user/repo"
+    assert "README.md" in result.content
+    assert "docs/principles.md" in result.content
+    assert "pyproject.toml" in result.content
+    assert "src/main.py" not in result.content
+    assert "docs/logo.png" not in result.content
+    assert result.source_references == [
+        "[README.md](https://github.com/user/repo/blob/main/README.md)",
+        "[docs/principles.md](https://github.com/user/repo/blob/main/docs/principles.md)",
+        "[pyproject.toml](https://github.com/user/repo/blob/main/pyproject.toml)",
+    ]
+    assert "https://api.github.com/repos/user/repo/contents/src/main.py" not in fetched_urls
+
+
+def test_github_provider_treats_tree_docs_url_as_documentation_root() -> None:
+    """A /tree/<ref>/docs URL should select docs files from that directory."""
+    provider = GitHubProvider()
+    responses = {
+        "https://api.github.com/repos/user/repo/contents/docs": FakeResponse(
+            [{"type": "file", "name": "usage.md", "path": "docs/usage.md"}]
+        ),
+        "https://api.github.com/repos/user/repo/contents/docs/usage.md": FakeResponse(
+            encoded_file("# Usage\n\nRun the CLI.")
+        ),
+    }
+
+    def fake_get(url: str, **kwargs: Any) -> FakeResponse:
+        return responses[url]
+
+    with patch("obsidian_ai_tools.providers.github.requests.get", side_effect=fake_get):
+        result = provider._ingest("https://github.com/user/repo/tree/main/docs")
+
+    assert result.url == "https://github.com/user/repo/tree/main"
+    assert "docs/usage.md" in result.content
+    assert result.source_references == [
+        "[docs/usage.md](https://github.com/user/repo/blob/main/docs/usage.md)"
+    ]
+
+
+def test_github_provider_reports_private_repo_without_token() -> None:
+    """Private repos produce an actionable credentials error."""
+    provider = GitHubProvider()
+    response = FakeResponse(
+        {"message": "Requires authentication"},
+        status_code=403,
+        headers={"X-RateLimit-Remaining": "42"},
+    )
+
+    with patch("obsidian_ai_tools.providers.github.requests.get", return_value=response):
+        with pytest.raises(GitHubRepositoryError, match="GITHUB_TOKEN"):
+            provider._ingest("https://github.com/user/private")
+
+
+def test_github_provider_reports_rate_limit() -> None:
+    """Unauthenticated rate limits point users toward a token."""
+    provider = GitHubProvider()
+    response = FakeResponse(
+        {"message": "API rate limit exceeded"},
+        status_code=403,
+        headers={"X-RateLimit-Remaining": "0"},
+    )
+
+    with patch("obsidian_ai_tools.providers.github.requests.get", return_value=response):
+        with pytest.raises(GitHubRepositoryError, match="rate limit exceeded"):
+            provider._ingest("https://github.com/user/repo")
+
+
+def test_github_provider_reports_insufficient_documentation() -> None:
+    """Repositories without docs fail before calling the LLM."""
+    provider = GitHubProvider()
+    responses = {
+        "https://api.github.com/repos/user/repo": FakeResponse({"default_branch": "main"}),
+        "https://api.github.com/repos/user/repo/contents": FakeResponse(
+            [{"type": "file", "name": "main.py", "path": "main.py"}]
+        ),
+    }
+
+    def fake_get(url: str, **kwargs: Any) -> FakeResponse:
+        return responses[url]
+
+    with patch("obsidian_ai_tools.providers.github.requests.get", side_effect=fake_get):
+        with pytest.raises(GitHubRepositoryError, match="No documentation files"):
+            provider._ingest("https://github.com/user/repo")
+
+
+def test_github_provider_uses_token_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GitHub requests include Authorization when GITHUB_TOKEN is configured."""
+    monkeypatch.setenv("GITHUB_TOKEN", "secret-token")
+    provider = GitHubProvider()
+
+    with patch("obsidian_ai_tools.providers.github.requests.get") as mock_get:
+        mock_get.return_value = FakeResponse({"default_branch": "main"})
+        provider._fetch_default_branch(provider_ref())
+
+    headers = mock_get.call_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer secret-token"
+
+
+def provider_ref() -> Any:
+    """Build a parsed repo ref without exposing parse details to this test."""
+    from obsidian_ai_tools.providers.github import parse_github_repo_url
+
+    ref = parse_github_repo_url("https://github.com/user/repo")
+    assert ref is not None
+    return ref

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -80,6 +80,7 @@ class TestSettingsIsolation:
             youtube_api_key="yt-key",
             decodo_api_key="decodo-key",
             supadata_key="supadata-key",
+            github_token="github-token",
             youtube_transcript_provider_order="decodo,direct",
             cache_dir=cache_path,
             cache_ttl_hours=24,
@@ -92,6 +93,7 @@ class TestSettingsIsolation:
         assert settings.llm_model == "openai/gpt-4"
         assert settings.max_transcript_length == 100000
         assert settings.youtube_api_key == "yt-key"
+        assert settings.github_token == "github-token"
         assert settings.cache_ttl_hours == 24
         assert settings.circuit_breaker_threshold == 5
         assert settings.max_pdf_pages == 100

--- a/tests/test_ingestion_service.py
+++ b/tests/test_ingestion_service.py
@@ -17,6 +17,7 @@ from obsidian_ai_tools.ingestion import (
     NoteGenerationStageError,
     ProviderSelectionError,
     VaultWriteError,
+    default_prompt_version,
     ingest_content,
 )
 from obsidian_ai_tools.models import ArticleMetadata, CostInfo, Note
@@ -64,6 +65,11 @@ def _cost_info() -> CostInfo:
         total_cost_usd=0.001,
         source_url="https://example.com/article",
     )
+
+
+def test_default_prompt_version_uses_github_repo_prompt() -> None:
+    """GitHub repository ingestion should use the repo-specific prompt by default."""
+    assert default_prompt_version("github") == "github_repo_v1"
 
 
 def test_ingest_content_runs_shared_pipeline_and_emits_progress(tmp_path: Path) -> None:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,13 +1,16 @@
 """Tests for LLM integration functionality."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from obsidian_ai_tools.llm import (
     NoteGenerationError,
     build_prompt,
+    generate_note,
     parse_llm_response,
 )
-from obsidian_ai_tools.models import VideoMetadata
+from obsidian_ai_tools.models import ArticleMetadata, VideoMetadata
 
 
 class TestBuildPrompt:
@@ -38,6 +41,25 @@ Transcript: {transcript}"""
         assert "https://youtube.com/watch?v=test123" in result
         assert "This is a test transcript." in result
 
+    def test_prompt_includes_github_repository_metadata(self) -> None:
+        """GitHub repo metadata should format through article-style templates."""
+        metadata = ArticleMetadata(
+            title="user/repo repository documentation",
+            url="https://github.com/user/repo",
+            author="user",
+            site_name="GitHub Repository",
+            content="Purpose: Test repository",
+            source_type="github",
+            source_references=["[README.md](https://github.com/user/repo/blob/main/README.md)"],
+        )
+        template = "Title: {title}\nURL: {url}\nContent: {content}"
+
+        result = build_prompt(metadata, template)
+
+        assert "user/repo repository documentation" in result
+        assert "https://github.com/user/repo" in result
+        assert "Purpose: Test repository" in result
+
 
 class TestParseLLMResponse:
     """Tests for parse_llm_response function."""
@@ -54,6 +76,52 @@ class TestParseLLMResponse:
         response = '```json\n{"title": "Test", "tags": ["tag1"]}\n```'
         result = parse_llm_response(response)
         assert result["title"] == "Test"
+
+
+class TestGenerateNote:
+    """Tests for note assembly from LLM responses."""
+
+    def test_generate_note_preserves_github_source_type_and_references(self) -> None:
+        """GitHub metadata should produce github notes with deterministic file references."""
+        metadata = ArticleMetadata(
+            title="user/repo repository documentation",
+            url="https://github.com/user/repo",
+            content="Repository docs",
+            author="user",
+            site_name="GitHub Repository",
+            source_type="github",
+            source_references=["[README.md](https://github.com/user/repo/blob/main/README.md)"],
+        )
+        mock_response = MagicMock()
+        mock_response.choices = [
+            MagicMock(
+                message=MagicMock(
+                    content=(
+                        '{"title": "Repo", "summary": "Summary", '
+                        '"key_points": ["Purpose"], "tags": ["repo"]}'
+                    )
+                )
+            )
+        ]
+        mock_response.usage = MagicMock(prompt_tokens=10, completion_tokens=5, cost=0.001)
+
+        with (
+            patch("obsidian_ai_tools.llm.load_prompt_template", return_value="{content}"),
+            patch("obsidian_ai_tools.llm.OpenAI") as mock_openai,
+        ):
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_openai.return_value = mock_client
+            note, cost_info = generate_note(
+                metadata=metadata,
+                model="test-model",
+                api_key="test-key",
+                prompt_version="github_repo_v1",
+            )
+
+        assert note.source_type == "github"
+        assert cost_info.source_type == "github"
+        assert note.source_references == metadata.source_references
 
     def test_parse_json_in_generic_code_block(self) -> None:
         """Test parsing JSON wrapped in ``` code block."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -102,3 +102,25 @@ class TestNote:
         )
         markdown = note.to_markdown()
         assert "author:" not in markdown
+
+    def test_to_markdown_includes_source_references(self) -> None:
+        """Test that source file references are included when provided."""
+        note = Note(
+            title="Test Note",
+            summary="Test summary",
+            tags=["test"],
+            source_url="https://github.com/user/repo",
+            source_type="github",
+            source_references=[
+                "[README.md](https://github.com/user/repo/blob/main/README.md)",
+                "[docs/usage.md](https://github.com/user/repo/blob/main/docs/usage.md)",
+            ],
+            model="test-model",
+        )
+
+        markdown = note.to_markdown()
+
+        assert "source_type: github" in markdown
+        assert "## Source Files" in markdown
+        assert "- [README.md](https://github.com/user/repo/blob/main/README.md)" in markdown
+        assert "- [docs/usage.md](https://github.com/user/repo/blob/main/docs/usage.md)" in markdown

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -132,11 +132,13 @@ class TestNote:
             summary="Repository summary",
             key_points=[
                 "Purpose: Explain the project goal",
-                "Principles: Local-first and bounded",
-                "Technology: Python and GitHub API",
+                "Architecture Read: Bounded GitHub documentation flows into a note renderer",
+                "Design Principles and Tradeoffs: Local-first and bounded",
+                "Technology and Runtime: Python and GitHub API",
                 "Usage Surface: CLI ingestion",
-                "Setup and Operations: Configure GITHUB_TOKEN for private repos",
-                "Caveats: Documentation may be incomplete",
+                "Security Posture: Configure GITHUB_TOKEN for private repos",
+                "Operational Maturity: Usable personal tool with focused tests",
+                "Caveats and Unknowns: Documentation may be incomplete",
             ],
             claims=["The docs claim bounded repo ingestion"],
             implications=["Repo notes are easier to scan"],
@@ -152,10 +154,13 @@ class TestNote:
         assert "## Key Points" not in markdown
         assert "## Purpose" in markdown
         assert "- Explain the project goal" in markdown
-        assert "## Principles" in markdown
-        assert "## Technology" in markdown
+        assert "## Architecture Read" in markdown
+        assert "## Design Principles and Tradeoffs" in markdown
+        assert "## Technology and Runtime" in markdown
         assert "## Usage Surface" in markdown
-        assert "## Setup and Operations" in markdown
-        assert "## Caveats" in markdown
-        assert "## Documented Claims" in markdown
+        assert "## Security Posture" in markdown
+        assert "## Operational Maturity" in markdown
+        assert "## Caveats and Unknowns" in markdown
+        assert "## Evidence Highlights" in markdown
+        assert "## Adoption Fit" in markdown
         assert "[GitHub Repository](https://github.com/user/repo)" in markdown

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -124,3 +124,38 @@ class TestNote:
         assert "## Source Files" in markdown
         assert "- [README.md](https://github.com/user/repo/blob/main/README.md)" in markdown
         assert "- [docs/usage.md](https://github.com/user/repo/blob/main/docs/usage.md)" in markdown
+
+    def test_github_note_uses_repository_sections(self) -> None:
+        """GitHub notes should render repo sections instead of generic key points."""
+        note = Note(
+            title="Test Repo",
+            summary="Repository summary",
+            key_points=[
+                "Purpose: Explain the project goal",
+                "Principles: Local-first and bounded",
+                "Technology: Python and GitHub API",
+                "Usage Surface: CLI ingestion",
+                "Setup and Operations: Configure GITHUB_TOKEN for private repos",
+                "Caveats: Documentation may be incomplete",
+            ],
+            claims=["The docs claim bounded repo ingestion"],
+            implications=["Repo notes are easier to scan"],
+            tags=["github"],
+            source_url="https://github.com/user/repo",
+            source_type="github",
+            source_references=["[README.md](https://github.com/user/repo/blob/main/README.md)"],
+            model="test-model",
+        )
+
+        markdown = note.to_markdown()
+
+        assert "## Key Points" not in markdown
+        assert "## Purpose" in markdown
+        assert "- Explain the project goal" in markdown
+        assert "## Principles" in markdown
+        assert "## Technology" in markdown
+        assert "## Usage Surface" in markdown
+        assert "## Setup and Operations" in markdown
+        assert "## Caveats" in markdown
+        assert "## Documented Claims" in markdown
+        assert "[GitHub Repository](https://github.com/user/repo)" in markdown


### PR DESCRIPTION
## Summary
- Add a GitHub repository provider that ingests bounded documentation sources instead of traversing the full repo.
- Render GitHub repo notes with repo-specific sections: Purpose, Principles, Technology, Usage Surface, Setup and Operations, Caveats.
- Add deterministic source-file provenance via `## Source Files`.
- Add a GitHub-specific prompt and optional `GITHUB_TOKEN` configuration for private repos/higher rate limits.
- Prioritize canonical `README.md` before localized README variants.

## Closes
Closes #42

## Acceptance Evidence
| Criterion | Evidence | Status |
| --- | --- | --- |
| Public GitHub repo URL with README creates a repo note | `tests/providers/test_github.py::test_github_provider_ingests_bounded_documentation_with_provenance` | Pass |
| Repo with README plus docs selects bounded docs and cites files | `tests/providers/test_github.py` provider selection/provenance assertions; `tests/test_models.py::test_to_markdown_includes_source_references` | Pass |
| Repo note uses the planned repo sections | `tests/test_models.py::test_github_note_uses_repository_sections` | Pass |
| Private repo without credentials gives actionable token message | `tests/providers/test_github.py::test_github_provider_reports_private_repo_without_token` | Pass |
| Missing/inaccessible/rate-limited repo reports GitHub failure clearly | `test_github_provider_reports_private_repo_without_token`, `test_github_provider_reports_rate_limit`, `test_github_provider_reports_insufficient_documentation` | Pass |
| Does not walk every source file by default | Provider only lists root plus docs dirs and test asserts `src/main.py` is not fetched | Pass |
| Tests cover URL detection, selection, inaccessible/private handling, provenance | `tests/providers/test_github.py`, `tests/test_llm.py`, `tests/test_ingestion_service.py`, `tests/test_models.py` | Pass |

## Validation
- `uv run --with pre-commit --with radon --with pytest pre-commit run --all-files` passed
- `uv run --no-project --with mypy --with pydantic --with pydantic-settings --with types-requests mypy --config-file mypy.ini .` passed
- `COVERAGE=1 uv run --with pytest --with coverage ./scripts/test.sh -q` passed: 380 tests, 83.17% coverage
- Push pre-push hooks passed: mypy and full coverage
- GitHub CI run #117 passed: security and build

Generated with Codex.