### PR TITLE
feat(server): show existing note before ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,13 +214,15 @@ The server binds to `127.0.0.1:8765` by default and exposes:
 | Method | Path | Purpose |
 | --- | --- | --- |
 | `GET` | `/status` | Report the configured vault, inbox, and model |
+| `GET` | `/lookup?url=` | Read-only duplicate check — is this source already in the vault? |
 | `POST` | `/ingest` | Run the full ingestion pipeline |
 | `GET` | `/docs` | OpenAPI documentation |
 
 To use the browser extension, start the server and load `chrome-extension/` as an unpacked extension in Chrome.
 Reload the unpacked extension after updating it. When ingesting an open ChatGPT or Claude conversation,
 the extension captures the rendered chat text from the authenticated browser tab before sending it to the
-local service.
+local service. On open, the popup checks `/lookup` and — if the page is already in the vault — shows the
+existing note, its tags, and an "Open in Obsidian" link, with the button switched to "Update existing note".
 
 ## Command Reference
 

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -49,6 +49,42 @@ async function init() {
 
   const serverOk = await checkServer();
   btn.disabled = !serverOk || !isSupportedUrl(currentUrl);
+
+  // Fire-and-forget: the popup is already usable at this point, and a slow or
+  // failing lookup must never block ingest or surface an error.
+  if (serverOk && isSupportedUrl(currentUrl)) {
+    checkExisting();
+  }
+}
+
+// Read-only duplicate check so the user sees "already in vault" without having
+// to click Ingest first. Silent on any failure — falls back to old behaviour.
+async function checkExisting() {
+  try {
+    const r = await fetch(`${SERVER}/lookup?url=${encodeURIComponent(currentUrl)}`, {
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!r.ok) return;
+
+    const data = await r.json();
+    if (!data.exists) return;
+
+    // A click may have started an ingest while the lookup was in flight; do not
+    // overwrite that result.
+    if (btn.disabled) return;
+
+    updateMode = true;
+    btnLabel.textContent = "Update existing note";
+    showResult(
+      "info",
+      `📄 Already in vault: ${data.title}`,
+      data.file_path,
+      data.tags ?? [],
+      data.obsidian_url,
+    );
+  } catch (_) {
+    // Timeout, offline server, or bad payload: leave the popup as-is.
+  }
 }
 
 // ── Result display ───────────────────────────────────────────────────────────

--- a/src/obsidian_ai_tools/server/app.py
+++ b/src/obsidian_ai_tools/server/app.py
@@ -12,7 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from ..config import get_settings
-from ..dedup import ExistingNote
+from ..dedup import ExistingNote, find_note_by_source
 from ..ingestion import (
     ContentFetchError,
     NoteGenerationStageError,
@@ -47,6 +47,15 @@ class IngestResponse(BaseModel):
     file_path: str
     tags: list[str]
     source_type: str
+    obsidian_url: str | None = None
+
+
+class LookupResponse(BaseModel):
+    exists: bool = False
+    title: str | None = None
+    file_path: str | None = None
+    tags: list[str] = []
+    source_type: str | None = None
     obsidian_url: str | None = None
 
 
@@ -90,6 +99,32 @@ def create_app() -> FastAPI:
             vault=str(settings.obsidian_vault_path),
             inbox=settings.obsidian_inbox_folder,
             model=settings.llm_model,
+        )
+
+    # Read-only duplicate check for the extension popup: it runs on popup open,
+    # so it must stay a frontmatter scan — no fetch, no LLM, no vault write.
+    # Declared sync so FastAPI runs the filesystem walk in the threadpool
+    # instead of blocking the event loop.
+    @app.get("/lookup", response_model=LookupResponse)
+    def lookup(url: str, vault_path: str | None = None) -> LookupResponse:
+        settings = get_settings()
+        vault = Path(vault_path) if vault_path else settings.obsidian_vault_path
+        existing = find_note_by_source(vault, url)
+        if existing is None:
+            return LookupResponse(exists=False)
+
+        try:
+            obsidian_url: str | None = build_obsidian_url(vault, existing.file_path)
+        except ValueError:
+            obsidian_url = None
+
+        return LookupResponse(
+            exists=True,
+            title=existing.title,
+            file_path=str(existing.file_path),
+            tags=existing.tags,
+            source_type=existing.source_type or "unknown",
+            obsidian_url=obsidian_url,
         )
 
     @app.post("/ingest", response_model=IngestResponse)

--- a/tests/test_ingestion_service.py
+++ b/tests/test_ingestion_service.py
@@ -377,6 +377,68 @@ def test_http_ingest_reports_existing_source(tmp_path: Path) -> None:
     )
 
 
+def test_http_lookup_reports_existing_note(tmp_path: Path) -> None:
+    """Test /lookup surfaces a matching note without running the pipeline."""
+    existing = ExistingNote(
+        file_path=tmp_path / "inbox" / "web-existing-note.md",
+        title="Existing Note",
+        tags=["test"],
+        source_type="web",
+    )
+
+    with (
+        patch("obsidian_ai_tools.server.app.get_settings", return_value=_settings(tmp_path)),
+        patch(
+            "obsidian_ai_tools.server.app.find_note_by_source", return_value=existing
+        ) as mock_find,
+        patch("obsidian_ai_tools.server.app.ingest_content") as mock_ingest,
+    ):
+        response = TestClient(create_app()).get(
+            "/lookup", params={"url": "https://example.com/article"}
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["exists"] is True
+    assert body["title"] == "Existing Note"
+    assert body["tags"] == ["test"]
+    assert body["source_type"] == "web"
+    assert body["obsidian_url"] == (
+        f"obsidian://open?vault={tmp_path.name}&file=inbox%2Fweb-existing-note.md"
+    )
+    mock_find.assert_called_once_with(tmp_path, "https://example.com/article")
+    mock_ingest.assert_not_called()
+
+
+def test_http_lookup_reports_missing_note(tmp_path: Path) -> None:
+    """Test /lookup returns exists=false when no note matches the source."""
+    with (
+        patch("obsidian_ai_tools.server.app.get_settings", return_value=_settings(tmp_path)),
+        patch("obsidian_ai_tools.server.app.find_note_by_source", return_value=None),
+    ):
+        response = TestClient(create_app()).get(
+            "/lookup", params={"url": "https://example.com/unknown"}
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "exists": False,
+        "title": None,
+        "file_path": None,
+        "tags": [],
+        "source_type": None,
+        "obsidian_url": None,
+    }
+
+
+def test_http_lookup_requires_url(tmp_path: Path) -> None:
+    """Test /lookup rejects a request with no url parameter."""
+    with patch("obsidian_ai_tools.server.app.get_settings", return_value=_settings(tmp_path)):
+        response = TestClient(create_app()).get("/lookup")
+
+    assert response.status_code == 422
+
+
 def test_cli_ingest_reports_existing_source(tmp_path: Path) -> None:
     """Test the CLI adapter prints the skip message for duplicates."""
     existing = ExistingNote(


### PR DESCRIPTION
Closes #45

Adds a read-only `GET /lookup?url=` endpoint that answers "is this source already in the vault?" using the existing `find_note_by_source` frontmatter scan — no fetch, no LLM, no vault write. The extension popup calls it on open and, on a hit, renders the note title, path, tags, and Obsidian link and switches the button to "Update existing note".

The lookup is fire-and-forget: it runs after the popup is already usable, uses the same 2s timeout as `/status`, fails silently, and skips rendering if an ingest started while it was in flight. Server offline or lookup error degrades to today's behaviour.

Measured against the real vault: ~35ms for both a hit and a full-scan miss.

Tests cover hit, miss, and a missing `url` param. The full suite passes apart from `tests/providers/test_github.py::test_github_provider_uses_token_header`, which fails on main too when a real GITHUB_TOKEN is present in the developer's .env (the test's monkeypatched value is overridden) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)