### PR TITLE
fix: remove the settings-leak mechanism and close the named test-quality gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ docs/decisions.md
 
 # Local uv environment resolution
 /uv.lock
+
+# Riptide artifacts (cloud-synced)
+.humanlayer/tasks/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ addopts = [
     "-ra",
     "--strict-markers",
     "--disable-warnings",
-    "--maxfail=1",
 ]
 testpaths = ["tests"]
 markers = [

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -26,8 +26,8 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ "${COVERAGE:-0}" = "1" ]; then
-    PYTHONPATH=. "$PYTHON" -m coverage run -m pytest --maxfail=1 --disable-warnings "$@"
+    PYTHONPATH=. "$PYTHON" -m coverage run -m pytest --disable-warnings "$@"
     "$PYTHON" -m coverage report
 else
-    PYTHONPATH=. "$PYTHON" -m pytest --maxfail=1 --disable-warnings "$@"
+    PYTHONPATH=. "$PYTHON" -m pytest --disable-warnings "$@"
 fi

--- a/src/obsidian_ai_tools/config.py
+++ b/src/obsidian_ai_tools/config.py
@@ -29,8 +29,12 @@ def find_env_file() -> Path | None:
 class Settings(BaseSettings):
     """Application settings loaded from environment variables and .env file."""
 
+    # NOTE: env_file is deliberately absent here. Setting it in the class body
+    # would call find_env_file() once, at import time, and freeze that absolute
+    # path onto the class for the lifetime of the process. get_settings()
+    # resolves the path per call and passes it via the documented per-instance
+    # `_env_file` override instead.
     model_config = SettingsConfigDict(
-        env_file=find_env_file() or ".env",
         env_file_encoding="utf-8",
         case_sensitive=False,
         extra="ignore",
@@ -144,7 +148,9 @@ def get_settings() -> Settings:
         )
 
     try:
-        return Settings()  # type: ignore[call-arg]
+        # Pass the path resolved just above, so the file we read is always the
+        # file the error messages below name.
+        return Settings(_env_file=env_file)  # type: ignore[call-arg]
     except Exception as e:
         # Provide helpful context for configuration errors
         error_msg = str(e)

--- a/src/obsidian_ai_tools/config.py
+++ b/src/obsidian_ai_tools/config.py
@@ -53,6 +53,10 @@ class Settings(BaseSettings):
         default="anthropic/claude-3.5-sonnet",
         description="OpenRouter model identifier",
     )
+    llm_base_url: str = Field(
+        default="https://openrouter.ai/api/v1",
+        description="OpenAI-compatible API base URL (e.g. LM Studio: http://localhost:1234/v1)",
+    )
     max_transcript_length: int = Field(
         default=50000, description="Maximum transcript length in characters"
     )

--- a/src/obsidian_ai_tools/ingestion.py
+++ b/src/obsidian_ai_tools/ingestion.py
@@ -197,6 +197,7 @@ def ingest_content(
             existing_tags=existing_tags,
             max_content_length=settings.max_transcript_length,
             prompt_version=prompt_version,
+            base_url=settings.llm_base_url,
         )
     except Exception as exc:
         raise NoteGenerationStageError(f"Note generation failed: {exc}") from exc

--- a/src/obsidian_ai_tools/llm.py
+++ b/src/obsidian_ai_tools/llm.py
@@ -122,6 +122,7 @@ def generate_note(
     existing_tags: str | None = None,
     max_content_length: int = 50000,
     prompt_version: str = "youtube_v1",
+    base_url: str = "https://openrouter.ai/api/v1",
 ) -> tuple[Note, CostInfo]:
     """Generate Obsidian note from content using OpenRouter.
 
@@ -162,7 +163,7 @@ def generate_note(
     prompt = build_prompt(metadata, template, existing_tags)
 
     client = OpenAI(
-        base_url="https://openrouter.ai/api/v1",
+        base_url=base_url,
         api_key=api_key,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,12 @@
 """Pytest configuration and fixtures."""
 
-import os
-import tempfile
 from collections.abc import Generator, Iterator
 from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
 
+from obsidian_ai_tools.config import get_settings
 from obsidian_ai_tools.observability import ObservabilityDB, _set_db_for_test
 
 
@@ -27,46 +26,61 @@ def _obs_db_tmp(tmp_path: Path) -> Generator[None, None, None]:
 
 
 @pytest.fixture(autouse=True)
-def mock_settings_env() -> Iterator[None]:
-    """Set up test environment variables for all tests.
+def _isolate_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Guarantee no test can read the developer's real .env.
 
-    Creates a temporary .env file with test configuration to avoid
-    requiring actual environment variables in test environment.
+    Two independent layers, both required:
+
+    Layer 1 - ``find_env_file()`` is redirected at the config module, so
+    ``get_settings()`` hands a throwaway .env to ``Settings(_env_file=...)``
+    instead of whatever real .env sits on the current working directory chain.
+
+    Layer 2 - the same keys are also exported as process environment
+    variables. Environment variables outrank dotenv values in
+    pydantic-settings' documented precedence, so a direct ``Settings(...)``
+    call - which reads no dotenv file at all now - is covered too.
+
+    The cache is cleared on setup *and* teardown so no test inherits another
+    test's Settings object.
     """
-    with tempfile.TemporaryDirectory() as tmpdir:
-        env_file = Path(tmpdir) / ".env"
+    base = tmp_path / "_kai_test_env"
+    vault = base / "vault"
+    (vault / "inbox").mkdir(parents=True)
+    cache_dir = base / "cache"
 
-        # Write minimal test configuration
-        env_content = """
-OPENROUTER_API_KEY=test_key_for_testing
-OBSIDIAN_VAULT_PATH=/tmp/test_vault
-OBSIDIAN_INBOX_FOLDER=inbox
-LLM_MODEL=anthropic/claude-3.5-sonnet
-MAX_TRANSCRIPT_LENGTH=50000
-YOUTUBE_TRANSCRIPT_PROVIDER_ORDER=direct,supadata,decodo
-CACHE_DIR=/tmp/test_cache
-CACHE_TTL_HOURS=168
-CIRCUIT_BREAKER_THRESHOLD=3
-CIRCUIT_BREAKER_TIMEOUT_HOURS=2
-MAX_PDF_PAGES=50
-MAX_PDF_SIZE_MB=20
-"""
+    test_env: dict[str, str] = {
+        "OPENROUTER_API_KEY": "test_key_for_testing",
+        "OBSIDIAN_VAULT_PATH": str(vault),
+        "OBSIDIAN_INBOX_FOLDER": "inbox",
+        "LLM_MODEL": "anthropic/claude-3.5-sonnet",
+        "MAX_TRANSCRIPT_LENGTH": "50000",
+        "YOUTUBE_TRANSCRIPT_PROVIDER_ORDER": "direct,supadata,decodo",
+        "CACHE_DIR": str(cache_dir),
+        "CACHE_TTL_HOURS": "168",
+        "CIRCUIT_BREAKER_THRESHOLD": "3",
+        "CIRCUIT_BREAKER_TIMEOUT_HOURS": "2",
+        "MAX_PDF_PAGES": "50",
+        "MAX_PDF_SIZE_MB": "20",
+        # Every remaining secret-bearing field needs a placeholder, otherwise
+        # the real .env value for it could still reach Settings.
+        "GITHUB_TOKEN": "test-github-token",
+        "YOUTUBE_API_KEY": "test-youtube-api-key",
+        "DECODO_API_KEY": "test-decodo-api-key",
+        "SUPADATA_KEY": "test-supadata-key",
+    }
 
-        env_file.write_text(env_content.strip())
+    # Layer 1: the only .env any test can reach.
+    env_file = base / ".env"
+    env_file.write_text("\n".join(f"{key}={value}" for key, value in test_env.items()) + "\n")
+    monkeypatch.setattr("obsidian_ai_tools.config.find_env_file", lambda: env_file)
 
-        # Set a temporary directory that can be used by tests
-        test_vault = Path("/tmp/test_vault")
-        test_vault.mkdir(exist_ok=True)
-        (test_vault / "inbox").mkdir(exist_ok=True)
+    # Layer 2: environment variables beat dotenv values.
+    for key, value in test_env.items():
+        monkeypatch.setenv(key, value)
 
-        # Change to temp directory where .env exists
-        original_cwd = os.getcwd()
-        os.chdir(tmpdir)
-
-        yield
-
-        # Cleanup
-        os.chdir(original_cwd)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
 
 
 # External Service Mocking Fixtures

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Generator, Iterator
 from pathlib import Path
-from unittest.mock import Mock
 
 import pytest
 
@@ -87,34 +86,6 @@ def _isolate_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterat
 
 
 @pytest.fixture
-def mock_requests_get() -> Mock:
-    """Mock requests.get for HTTP GET calls.
-
-    Returns a Mock that can be configured per-test.
-    Use with @patch decorator or as a fixture.
-    """
-    mock = Mock()
-    mock.return_value.status_code = 200
-    mock.return_value.headers = {"content-type": "text/html"}
-    mock.return_value.text = "<html><body>Test content</body></html>"
-    mock.return_value.raise_for_status = Mock()
-    return mock
-
-
-@pytest.fixture
-def mock_requests_post() -> Mock:
-    """Mock requests.post for HTTP POST calls.
-
-    Returns a Mock that can be configured per-test.
-    """
-    mock = Mock()
-    mock.return_value.status_code = 200
-    mock.return_value.json.return_value = {"status": "success"}
-    mock.return_value.raise_for_status = Mock()
-    return mock
-
-
-@pytest.fixture
 def mock_supadata_response() -> dict[str, str]:
     """Mock successful Supadata API response.
 
@@ -128,36 +99,6 @@ def mock_supadata_response() -> dict[str, str]:
         "author": "Test Author",
         "date_published": "2026-01-04T12:00:00Z",
     }
-
-
-@pytest.fixture
-def mock_openrouter_response() -> dict[str, list[dict[str, dict[str, str]]]]:
-    """Mock successful OpenRouter API response.
-
-    Provides a standard LLM response from OpenRouter.
-    """
-    return {
-        "choices": [
-            {
-                "message": {
-                    "content": '{"title": "Test Note", "summary": "Test summary", "tags": ["test"]}'
-                }
-            }
-        ]
-    }
-
-
-@pytest.fixture
-def mock_youtube_transcript() -> list[dict[str, float | str]]:
-    """Mock YouTube transcript data.
-
-    Provides sample transcript data as returned by youtube_transcript_api.
-    """
-    return [
-        {"text": "Hello, this is a test video.", "start": 0.0, "duration": 3.5},
-        {"text": "This is the second segment.", "start": 3.5, "duration": 2.8},
-        {"text": "And this is the final part.", "start": 6.3, "duration": 3.2},
-    ]
 
 
 @pytest.fixture
@@ -179,16 +120,23 @@ def mock_pdf_content(tmp_path: Path) -> bytes:
     return pdf_path.read_bytes()
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture(autouse=True)
 def disable_network_calls(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Fixture to disable all network calls.
+    """Block real outbound HTTP for every test.
 
-    Use this fixture in tests that should never make real network calls.
-    If any code tries to use requests.get/post, it will raise an error.
+    Autouse, so no test has to opt in. Any unpatched ``requests.get`` or
+    ``requests.post`` raises ``RuntimeError("Attempted real network call...")``
+    instead of reaching the internet.
 
-    Usage:
-        def test_something(disable_network_calls):
-            # Test code here - network calls will fail
+    Scope limit, stated plainly: this replaces ``requests.get`` and
+    ``requests.post`` and *nothing else*. It does **not** cover ``httpx``
+    (which the OpenAI client uses), ``urllib``, or raw sockets. Those still
+    have to be patched per test.
+
+    Module-boundary patches keep working. A test doing
+    ``patch("obsidian_ai_tools.providers.web.requests.get")`` targets the same
+    ``requests`` module object this fixture patched, so the test's mock wins
+    for the duration of the patch and the guard is restored afterwards.
     """
 
     def mock_get(*args: object, **kwargs: object) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
 """Pytest configuration and fixtures."""
 
 from collections.abc import Generator, Iterator
+from contextlib import contextmanager
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -80,6 +82,49 @@ def _isolate_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterat
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()
+
+
+# Shared Test Helpers
+
+
+@contextmanager
+def patched_openai(
+    content: str,
+    *,
+    prompt_tokens: int = 50,
+    completion_tokens: int = 30,
+    cost: float = 0.001,
+) -> Iterator[MagicMock]:
+    """Patch ``obsidian_ai_tools.llm.OpenAI`` with a canned chat completion.
+
+    Replaces the ~10-line ``MagicMock`` scaffold that ``generate_note`` tests
+    would otherwise rebuild by hand. Only the two things that carry meaning are
+    parameters: the JSON payload the model "returns", and the usage numbers the
+    cost calculation reads back.
+
+    Args:
+        content: Raw ``message.content`` string, normally a JSON note payload.
+        prompt_tokens: Value for ``usage.prompt_tokens``.
+        completion_tokens: Value for ``usage.completion_tokens``.
+        cost: Value for ``usage.cost``.
+
+    Yields:
+        The patched ``OpenAI`` class mock, so a test can assert on how the
+        client was constructed or called.
+    """
+    response = MagicMock()
+    response.choices = [MagicMock(message=MagicMock(content=content))]
+    response.usage = MagicMock(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        cost=cost,
+    )
+
+    with patch("obsidian_ai_tools.llm.OpenAI") as mock_openai:
+        client = MagicMock()
+        client.chat.completions.create.return_value = response
+        mock_openai.return_value = client
+        yield mock_openai
 
 
 # External Service Mocking Fixtures

--- a/tests/providers/test_github.py
+++ b/tests/providers/test_github.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from obsidian_ai_tools.config import get_settings
 from obsidian_ai_tools.providers.factory import ProviderFactory
 from obsidian_ai_tools.providers.github import GitHubProvider, GitHubRepositoryError
 from obsidian_ai_tools.providers.web import WebProvider
@@ -213,12 +214,13 @@ def test_github_provider_reports_insufficient_documentation() -> None:
 
 def test_github_provider_uses_token_header(monkeypatch: pytest.MonkeyPatch) -> None:
     """GitHub requests include Authorization when GITHUB_TOKEN is configured."""
+    # No get_settings patch needed: environment variables outrank dotenv
+    # values, so the rebuilt Settings carry this placeholder and _load_token()
+    # returns it through its normal path.
     monkeypatch.setenv("GITHUB_TOKEN", "secret-token")
-    with patch(
-        "obsidian_ai_tools.providers.github.get_settings",
-        side_effect=RuntimeError("no settings in test"),
-    ):
-        provider = GitHubProvider()
+    get_settings.cache_clear()
+
+    provider = GitHubProvider()
 
     with patch("obsidian_ai_tools.providers.github.requests.get") as mock_get:
         mock_get.return_value = FakeResponse({"default_branch": "main"})

--- a/tests/providers/test_github.py
+++ b/tests/providers/test_github.py
@@ -214,7 +214,11 @@ def test_github_provider_reports_insufficient_documentation() -> None:
 def test_github_provider_uses_token_header(monkeypatch: pytest.MonkeyPatch) -> None:
     """GitHub requests include Authorization when GITHUB_TOKEN is configured."""
     monkeypatch.setenv("GITHUB_TOKEN", "secret-token")
-    provider = GitHubProvider()
+    with patch(
+        "obsidian_ai_tools.providers.github.get_settings",
+        side_effect=RuntimeError("no settings in test"),
+    ):
+        provider = GitHubProvider()
 
     with patch("obsidian_ai_tools.providers.github.requests.get") as mock_get:
         mock_get.return_value = FakeResponse({"default_branch": "main"})

--- a/tests/providers/test_youtube_provider.py
+++ b/tests/providers/test_youtube_provider.py
@@ -1,0 +1,185 @@
+"""Tests for the YouTubeProvider wrapper in providers/youtube.py.
+
+The wrapper itself owns three behaviours worth asserting: URL validation, the
+``provider_order`` forwarding out of ``**kwargs``, and the observability
+bookkeeping around the client call. Everything else lives in
+``obsidian_ai_tools.youtube`` and is covered by tests/providers/test_youtube_providers.py.
+
+Patch targets differ by import style:
+
+* ``YouTubeClient`` is imported *inside* ``_ingest``, so the statement re-runs on
+  every call and the defining module is the only stable target
+  (``obsidian_ai_tools.youtube.YouTubeClient``).
+* ``get_db`` is a module-level import, so it is patched at the use site
+  (``obsidian_ai_tools.providers.youtube.get_db``).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from obsidian_ai_tools.models import VideoMetadata
+from obsidian_ai_tools.providers.youtube import YouTubeProvider
+from obsidian_ai_tools.youtube_exceptions import TranscriptUnavailableError
+
+URL = "https://www.youtube.com/watch?v=abc123"
+
+
+def _metadata() -> VideoMetadata:
+    """A minimal, valid result for the mocked client to return."""
+    return VideoMetadata(
+        video_id="abc123",
+        title="Test Video",
+        url=URL,
+        transcript="Some transcript text.",
+        channel_name="Test Channel",
+        provider_used="direct",
+    )
+
+
+def _client_returning(result: VideoMetadata) -> MagicMock:
+    client = MagicMock()
+    client.get_video_metadata.return_value = result
+    return client
+
+
+def _client_raising(exc: Exception) -> MagicMock:
+    client = MagicMock()
+    client.get_video_metadata.side_effect = exc
+    return client
+
+
+def test_provider_name_is_youtube() -> None:
+    """The factory keys providers by name, so the literal matters."""
+    assert YouTubeProvider().name == "youtube"
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("https://www.youtube.com/watch?v=abc123", True),
+        ("https://youtube.com/shorts/abc123", True),
+        ("https://youtu.be/abc123", True),
+        ("http://m.youtube.com/watch?v=abc123", True),
+        ("https://example.com/watch?v=abc123", False),
+        ("https://vimeo.com/123456", False),
+        ("/local/path/video.mp4", False),
+    ],
+)
+def test_validate_matches_only_youtube_sources(source: str, expected: bool) -> None:
+    """validate() gates which provider the factory selects for a source."""
+    assert YouTubeProvider().validate(source) is expected
+
+
+def test_ingest_returns_client_result_and_records_a_success_attempt() -> None:
+    """A successful fetch is returned untouched and logged as primary/success."""
+    metadata = _metadata()
+    client = _client_returning(metadata)
+    db = MagicMock()
+
+    with (
+        patch("obsidian_ai_tools.youtube.YouTubeClient", return_value=client) as client_cls,
+        patch("obsidian_ai_tools.providers.youtube.get_db", return_value=db),
+    ):
+        result = YouTubeProvider()._ingest(URL)
+
+    assert result is metadata
+    # The production caller constructs the client with no settings argument.
+    client_cls.assert_called_once_with()
+
+    db.record_provider_attempt.assert_called_once()
+    args = db.record_provider_attempt.call_args.args
+    kwargs = db.record_provider_attempt.call_args.kwargs
+    assert args[:3] == ("youtube", "primary", "success")
+    assert isinstance(args[3], float)
+    assert args[3] >= 0.0
+    assert kwargs == {"url": URL}
+
+
+def test_ingest_records_a_failure_attempt_and_reraises() -> None:
+    """Observability must not swallow the error the caller needs to see."""
+    error = TranscriptUnavailableError("all providers failed")
+    db = MagicMock()
+
+    with (
+        patch("obsidian_ai_tools.youtube.YouTubeClient", return_value=_client_raising(error)),
+        patch("obsidian_ai_tools.providers.youtube.get_db", return_value=db),
+        pytest.raises(TranscriptUnavailableError, match="all providers failed"),
+    ):
+        YouTubeProvider()._ingest(URL)
+
+    db.record_provider_attempt.assert_called_once()
+    args = db.record_provider_attempt.call_args.args
+    assert args[:3] == ("youtube", "primary", "failure")
+    assert isinstance(args[3], float)
+    assert args[3] >= 0.0
+    assert args[4] == "TranscriptUnavailableError"
+    assert args[5] == URL
+
+
+@pytest.mark.parametrize("provider_order", ["supadata,direct", "decodo", None])
+def test_ingest_forwards_provider_order_from_kwargs(provider_order: str | None) -> None:
+    """provider_order is not a declared parameter; it is plucked from **kwargs.
+
+    The None case is the default CLI path, where the client falls back to the
+    configured order instead of an override.
+    """
+    client = _client_returning(_metadata())
+    kwargs = {} if provider_order is None else {"provider_order": provider_order}
+
+    with (
+        patch("obsidian_ai_tools.youtube.YouTubeClient", return_value=client),
+        patch("obsidian_ai_tools.providers.youtube.get_db", return_value=MagicMock()),
+    ):
+        YouTubeProvider()._ingest(URL, **kwargs)
+
+    client.get_video_metadata.assert_called_once_with(URL, provider_order=provider_order)
+
+
+def test_ingest_ignores_unrelated_kwargs() -> None:
+    """Only provider_order is forwarded; other ingest options are dropped here."""
+    client = _client_returning(_metadata())
+
+    with (
+        patch("obsidian_ai_tools.youtube.YouTubeClient", return_value=client),
+        patch("obsidian_ai_tools.providers.youtube.get_db", return_value=MagicMock()),
+    ):
+        YouTubeProvider()._ingest(URL, captured_content="ignored", vault="ignored")
+
+    client.get_video_metadata.assert_called_once_with(URL, provider_order=None)
+
+
+def test_ingest_succeeds_when_observability_is_broken() -> None:
+    """A dead DuckDB must never turn a good fetch into a failure."""
+    metadata = _metadata()
+
+    with (
+        patch(
+            "obsidian_ai_tools.youtube.YouTubeClient",
+            return_value=_client_returning(metadata),
+        ),
+        patch(
+            "obsidian_ai_tools.providers.youtube.get_db",
+            side_effect=RuntimeError("observability database unavailable"),
+        ),
+    ):
+        result = YouTubeProvider()._ingest(URL)
+
+    assert result is metadata
+
+
+def test_ingest_reraises_original_error_when_observability_is_broken() -> None:
+    """On the failure path the ingest error wins over the observability error."""
+    error = TranscriptUnavailableError("all providers failed")
+
+    with (
+        patch("obsidian_ai_tools.youtube.YouTubeClient", return_value=_client_raising(error)),
+        patch(
+            "obsidian_ai_tools.providers.youtube.get_db",
+            side_effect=RuntimeError("observability database unavailable"),
+        ),
+        pytest.raises(TranscriptUnavailableError, match="all providers failed") as excinfo,
+    ):
+        YouTubeProvider()._ingest(URL)
+
+    assert excinfo.value is error

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,31 @@ from unittest.mock import patch
 
 import pytest
 
-from obsidian_ai_tools.config import Settings, get_settings
+# NOTE: find_env_file is imported here, at module level, on purpose. The autouse
+# _isolate_settings fixture in conftest.py replaces the *attribute*
+# obsidian_ai_tools.config.find_env_file, so a function-body import would hand
+# TestFindEnvFile the patched stub instead of the real walk. A module-level
+# import binds the original function object at collection time, before any
+# fixture runs, which is exactly what those tests need.
+from obsidian_ai_tools.config import Settings, find_env_file, get_settings
+
+# The attribute the autouse fixture patches, and the one these tests re-point.
+_FIND_ENV_FILE = "obsidian_ai_tools.config.find_env_file"
+
+
+def _make_vault(tmp_path: Path, name: str = "vault") -> Path:
+    """Create a vault directory that passes validate_vault_path."""
+    vault = tmp_path / name
+    vault.mkdir(parents=True, exist_ok=True)
+    return vault
+
+
+def _write_env_file(directory: Path, **values: str) -> Path:
+    """Write a .env file into ``directory`` and return its path."""
+    directory.mkdir(parents=True, exist_ok=True)
+    env_path = directory / ".env"
+    env_path.write_text("\n".join(f"{key}={value}" for key, value in values.items()) + "\n")
+    return env_path
 
 
 @pytest.fixture
@@ -188,34 +212,42 @@ class TestSettingsValidation:
 
 
 class TestGetSettingsCache:
-    """Tests for get_settings caching behavior."""
+    """Tests for get_settings() end to end: caching and the file it reads.
 
-    def test_get_settings_is_cached(self) -> None:
-        """Test that get_settings returns same instance."""
-        # Clear the cache first
+    Every test here points find_env_file() at its own throwaway .env, which
+    overrides the redirect the autouse _isolate_settings fixture installs. The
+    cache is cleared explicitly before each assertion so no ordering assumption
+    is needed; the fixture clears it again on teardown.
+    """
+
+    def test_get_settings_is_cached(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Repeat calls return the one cached instance."""
+        vault = _make_vault(tmp_path)
+        env_path = _write_env_file(
+            tmp_path / "config",
+            OPENROUTER_API_KEY="cache-test-key",
+            OBSIDIAN_VAULT_PATH=str(vault),
+        )
+        monkeypatch.setattr(_FIND_ENV_FILE, lambda: env_path)
         get_settings.cache_clear()
-
-        # Skip this test if no .env file exists
-        from obsidian_ai_tools.config import find_env_file
-
-        if find_env_file() is None:
-            pytest.skip("No .env file found - skipping cache test")
 
         settings1 = get_settings()
         settings2 = get_settings()
 
-        # Should be the exact same object (cached)
         assert settings1 is settings2
+        assert get_settings.cache_info().currsize == 1
 
-        # Clean up
-        get_settings.cache_clear()
-
-    def test_cache_clear_reloads_settings(self) -> None:
-        """Test that clearing cache allows reloading settings."""
-        from obsidian_ai_tools.config import find_env_file
-
-        if find_env_file() is None:
-            pytest.skip("No .env file found - skipping cache test")
+    def test_cache_clear_reloads_settings(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """cache_clear() yields a distinct object carrying the same values."""
+        vault = _make_vault(tmp_path)
+        env_path = _write_env_file(
+            tmp_path / "config",
+            OPENROUTER_API_KEY="cache-test-key",
+            OBSIDIAN_VAULT_PATH=str(vault),
+        )
+        monkeypatch.setattr(_FIND_ENV_FILE, lambda: env_path)
 
         get_settings.cache_clear()
         settings1 = get_settings()
@@ -223,10 +255,174 @@ class TestGetSettingsCache:
         get_settings.cache_clear()
         settings2 = get_settings()
 
-        # Should be different objects after cache clear
         assert settings1 is not settings2
-        # But should have same values
         assert settings1.openrouter_api_key == settings2.openrouter_api_key
+        assert settings1.obsidian_vault_path == settings2.obsidian_vault_path
 
-        # Clean up
+    def test_get_settings_reads_the_file_find_env_file_reports(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression test for passing _env_file per call.
+
+        Before that change, Settings read one absolute path frozen at import
+        time, so re-pointing find_env_file() changed nothing. Now the values
+        must follow the file.
+        """
+        vault = _make_vault(tmp_path)
+
+        # Environment variables outrank dotenv values in pydantic-settings, and
+        # the autouse fixture exports this key. Drop it so the dotenv file is
+        # what decides.
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+        first = _write_env_file(
+            tmp_path / "first",
+            OPENROUTER_API_KEY="key-from-first-env-file",
+            OBSIDIAN_VAULT_PATH=str(vault),
+        )
+        second = _write_env_file(
+            tmp_path / "second",
+            OPENROUTER_API_KEY="key-from-second-env-file",
+            OBSIDIAN_VAULT_PATH=str(vault),
+        )
+
+        monkeypatch.setattr(_FIND_ENV_FILE, lambda: first)
         get_settings.cache_clear()
+        assert get_settings().openrouter_api_key == "key-from-first-env-file"
+
+        monkeypatch.setattr(_FIND_ENV_FILE, lambda: second)
+        get_settings.cache_clear()
+        assert get_settings().openrouter_api_key == "key-from-second-env-file"
+
+
+class TestGetSettingsErrors:
+    """Tests for the two RuntimeError branches in get_settings()."""
+
+    def test_missing_env_file_raises_runtime_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No .env anywhere is a pre-flight failure with recovery guidance."""
+        monkeypatch.setattr(_FIND_ENV_FILE, lambda: None)
+        get_settings.cache_clear()
+
+        with pytest.raises(RuntimeError, match="Could not find .env file") as exc_info:
+            get_settings()
+
+        assert "~/.kai/.env" in str(exc_info.value)
+
+    def test_validation_error_names_the_file_that_was_read(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A bad .env is wrapped, and the message quotes the file actually read."""
+        vault = _make_vault(tmp_path)
+
+        # The autouse fixture exports a valid provider order; the dotenv value
+        # only reaches the validator once the environment variable is gone.
+        monkeypatch.delenv("YOUTUBE_TRANSCRIPT_PROVIDER_ORDER", raising=False)
+
+        env_path = _write_env_file(
+            tmp_path / "bad",
+            OPENROUTER_API_KEY="test-key",
+            OBSIDIAN_VAULT_PATH=str(vault),
+            YOUTUBE_TRANSCRIPT_PROVIDER_ORDER="not-a-provider",
+        )
+        monkeypatch.setattr(_FIND_ENV_FILE, lambda: env_path)
+        get_settings.cache_clear()
+
+        with pytest.raises(RuntimeError, match="Configuration error") as exc_info:
+            get_settings()
+
+        message = str(exc_info.value)
+        assert str(env_path) in message
+        assert "Invalid provider name" in message
+
+    def test_non_validation_error_propagates_unchanged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Anything that is not a validation error escapes with its own type."""
+        vault = _make_vault(tmp_path)
+        env_path = _write_env_file(
+            tmp_path / "config",
+            OPENROUTER_API_KEY="test-key",
+            OBSIDIAN_VAULT_PATH=str(vault),
+        )
+        monkeypatch.setattr(_FIND_ENV_FILE, lambda: env_path)
+
+        def explode(**kwargs: object) -> Settings:
+            raise OSError("dotenv file is unreadable")
+
+        monkeypatch.setattr("obsidian_ai_tools.config.Settings", explode)
+        get_settings.cache_clear()
+
+        with pytest.raises(OSError, match="dotenv file is unreadable"):
+            get_settings()
+
+
+class TestFindEnvFile:
+    """Tests for the real find_env_file() upward walk and home fallback.
+
+    These call the module-level import at the top of this file, which is the
+    original function - the autouse fixture only replaces the attribute on the
+    config module.
+    """
+
+    def test_finds_env_in_the_current_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The walk starts at the working directory itself."""
+        env_path = tmp_path / ".env"
+        env_path.write_text("OPENROUTER_API_KEY=test-key\n")
+        monkeypatch.chdir(tmp_path)
+
+        assert find_env_file() == env_path
+
+    def test_walks_up_to_a_parent_directory(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A .env two levels up is found from a nested working directory."""
+        env_path = tmp_path / ".env"
+        env_path.write_text("OPENROUTER_API_KEY=test-key\n")
+        leaf = tmp_path / "project" / "src"
+        leaf.mkdir(parents=True)
+        monkeypatch.chdir(leaf)
+
+        assert find_env_file() == env_path
+
+    def test_nearest_env_file_wins(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The first .env encountered on the way up is the one returned."""
+        (tmp_path / ".env").write_text("OPENROUTER_API_KEY=outer\n")
+        inner = tmp_path / "project"
+        inner.mkdir()
+        inner_env = inner / ".env"
+        inner_env.write_text("OPENROUTER_API_KEY=inner\n")
+        monkeypatch.chdir(inner)
+
+        assert find_env_file() == inner_env
+
+    def test_falls_back_to_home_kai_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With nothing on the cwd chain, ~/.kai/.env is used."""
+        workdir = tmp_path / "work"
+        workdir.mkdir()
+        home = tmp_path / "home"
+        (home / ".kai").mkdir(parents=True)
+        home_env = home / ".kai" / ".env"
+        home_env.write_text("OPENROUTER_API_KEY=test-key\n")
+
+        monkeypatch.chdir(workdir)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        assert find_env_file() == home_env
+
+    def test_returns_none_when_nothing_is_found(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No .env on the chain and no home fallback means None."""
+        workdir = tmp_path / "work"
+        workdir.mkdir()
+        home = tmp_path / "home"
+        home.mkdir()
+
+        monkeypatch.chdir(workdir)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+        assert find_env_file() is None

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -9,51 +9,8 @@ import pytest
 class TestMockingFixtures:
     """Tests to validate external service mocking fixtures."""
 
-    def test_mock_requests_get_fixture(self, mock_requests_get: Mock) -> None:
-        """Test that mock_requests_get fixture works."""
-        assert mock_requests_get is not None
-        assert mock_requests_get.return_value.status_code == 200
-        assert "content-type" in mock_requests_get.return_value.headers
-
-    def test_mock_requests_post_fixture(self, mock_requests_post: Mock) -> None:
-        """Test that mock_requests_post fixture works."""
-        assert mock_requests_post is not None
-        assert mock_requests_post.return_value.status_code == 200
-        result = mock_requests_post.return_value.json()
-        assert result["status"] == "success"
-
-    def test_mock_supadata_response_fixture(self, mock_supadata_response: dict[str, str]) -> None:
-        """Test that mock_supadata_response fixture provides valid data."""
-        assert "content" in mock_supadata_response
-        assert "title" in mock_supadata_response
-        assert mock_supadata_response["title"] == "Test Article Title"
-
-    def test_mock_openrouter_response_fixture(
-        self, mock_openrouter_response: dict[str, list[dict[str, dict[str, str]]]]
-    ) -> None:
-        """Test that mock_openrouter_response fixture provides valid LLM response."""
-        assert "choices" in mock_openrouter_response
-        assert len(mock_openrouter_response["choices"]) > 0
-        message = mock_openrouter_response["choices"][0]["message"]
-        assert "content" in message
-
-    def test_mock_youtube_transcript_fixture(
-        self, mock_youtube_transcript: list[dict[str, float | str]]
-    ) -> None:
-        """Test that mock_youtube_transcript fixture provides valid data."""
-        assert isinstance(mock_youtube_transcript, list)
-        assert len(mock_youtube_transcript) > 0
-        assert "text" in mock_youtube_transcript[0]
-        assert "start" in mock_youtube_transcript[0]
-
-    def test_mock_pdf_content_fixture(self, mock_pdf_content: bytes) -> None:
-        """Test that mock_pdf_content fixture creates valid PDF bytes."""
-        assert isinstance(mock_pdf_content, bytes)
-        # PDF files start with %PDF
-        assert mock_pdf_content.startswith(b"%PDF")
-
-    def test_disable_network_calls_fixture(self, disable_network_calls: None) -> None:
-        """Test that disable_network_calls prevents real network requests."""
+    def test_disable_network_calls_fixture(self) -> None:
+        """The autouse network guard blocks real requests.get/post calls."""
         import requests
 
         # Attempting to make real network call should raise error
@@ -109,12 +66,3 @@ class TestFixtureIntegrationWithProviders:
 
             # This would normally make real network calls, but we've mocked them
             # The test demonstrates the mocking infrastructure works
-
-    def test_fixture_customization_per_test(self, mock_requests_get: Mock) -> None:
-        """Test that fixtures can be customized per-test."""
-        # Customize the mock for this specific test
-        mock_requests_get.return_value.status_code = 404
-        mock_requests_get.return_value.headers = {"content-type": "application/json"}
-
-        assert mock_requests_get.return_value.status_code == 404
-        assert mock_requests_get.return_value.headers["content-type"] == "application/json"

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from conftest import patched_openai
 from typer.testing import CliRunner
 
 from obsidian_ai_tools.cli import app
@@ -77,22 +78,10 @@ More content here. Bullet points:
             published_date=None,
         )
 
-        mock_llm_response = MagicMock()
-        mock_llm_response.choices = [
-            MagicMock(
-                message=MagicMock(
-                    content='{"title": "Ingested Note", "summary": "Test summary", '
-                    '"key_points": ["Point 1", "Point 2"], "tags": ["test", "markdown"]}'
-                )
-            )
-        ]
-        mock_llm_response.usage = MagicMock(prompt_tokens=50, completion_tokens=30, cost=0.001)
-
-        with patch("obsidian_ai_tools.llm.OpenAI") as mock_openai:
-            mock_client = MagicMock()
-            mock_client.chat.completions.create.return_value = mock_llm_response
-            mock_openai.return_value = mock_client
-
+        with patched_openai(
+            '{"title": "Ingested Note", "summary": "Test summary", '
+            '"key_points": ["Point 1", "Point 2"], "tags": ["test", "markdown"]}'
+        ):
             from obsidian_ai_tools.llm import generate_note
 
             note, _ = generate_note(
@@ -167,22 +156,10 @@ class TestWebProviderIngest:
             published_date=None,
         )
 
-        mock_llm_response = MagicMock()
-        mock_llm_response.choices = [
-            MagicMock(
-                message=MagicMock(
-                    content='{"title": "Web Article Summary", "summary": "Test summary", '
-                    '"key_points": ["Key point"], "tags": ["web", "article"]}'
-                )
-            )
-        ]
-        mock_llm_response.usage = MagicMock(prompt_tokens=50, completion_tokens=30, cost=0.001)
-
-        with patch("obsidian_ai_tools.llm.OpenAI") as mock_openai:
-            mock_client = MagicMock()
-            mock_client.chat.completions.create.return_value = mock_llm_response
-            mock_openai.return_value = mock_client
-
+        with patched_openai(
+            '{"title": "Web Article Summary", "summary": "Test summary", '
+            '"key_points": ["Key point"], "tags": ["web", "article"]}'
+        ):
             from obsidian_ai_tools.llm import generate_note
 
             note, _ = generate_note(
@@ -385,22 +362,13 @@ class TestPDFProviderIngest:
             published_date=None,
         )
 
-        mock_llm_response = MagicMock()
-        mock_llm_response.choices = [
-            MagicMock(
-                message=MagicMock(
-                    content='{"title": "Paper Summary", "summary": "ML research summary", '
-                    '"key_points": ["Neural networks", "Transformers"], "tags": ["ml", "research"]}'
-                )
-            )
-        ]
-        mock_llm_response.usage = MagicMock(prompt_tokens=100, completion_tokens=50, cost=0.002)
-
-        with patch("obsidian_ai_tools.llm.OpenAI") as mock_openai:
-            mock_client = MagicMock()
-            mock_client.chat.completions.create.return_value = mock_llm_response
-            mock_openai.return_value = mock_client
-
+        with patched_openai(
+            '{"title": "Paper Summary", "summary": "ML research summary", '
+            '"key_points": ["Neural networks", "Transformers"], "tags": ["ml", "research"]}',
+            prompt_tokens=100,
+            completion_tokens=50,
+            cost=0.002,
+        ):
             from obsidian_ai_tools.llm import generate_note
 
             note, _ = generate_note(
@@ -449,27 +417,16 @@ class TestYouTubeIngestEnhanced:
             video_id="abc123",
         )
 
-        mock_llm_response = MagicMock()
-        mock_llm_response.choices = [
-            MagicMock(
-                message=MagicMock(
-                    content=(
-                        '{"title": "AI Techniques Overview", "summary": "Advanced methods", '
-                        '"key_points": ["RL", "Policy Gradients"], '
-                        '"claims": ["Outperforms supervised"], '
-                        '"implications": ["Future of autonomous systems"], '
-                        '"tags": ["ai", "ml"]}'
-                    )
-                )
-            )
-        ]
-        mock_llm_response.usage = MagicMock(prompt_tokens=100, completion_tokens=80, cost=0.002)
-
-        with patch("obsidian_ai_tools.llm.OpenAI") as mock_openai:
-            mock_client = MagicMock()
-            mock_client.chat.completions.create.return_value = mock_llm_response
-            mock_openai.return_value = mock_client
-
+        with patched_openai(
+            '{"title": "AI Techniques Overview", "summary": "Advanced methods", '
+            '"key_points": ["RL", "Policy Gradients"], '
+            '"claims": ["Outperforms supervised"], '
+            '"implications": ["Future of autonomous systems"], '
+            '"tags": ["ai", "ml"]}',
+            prompt_tokens=100,
+            completion_tokens=80,
+            cost=0.002,
+        ):
             from obsidian_ai_tools.llm import generate_note
 
             note, _ = generate_note(
@@ -493,12 +450,17 @@ class TestYouTubeIngestEnhanced:
             assert "## Key Claims" in content
             assert "## Implications" in content
 
-    def test_youtube_ingest_provider_fallback_logging(self, temp_vault: Path) -> None:
-        """Test that provider fallback is tracked in metadata."""
+    def test_youtube_ingest_provider_fallback_logging(
+        self, temp_vault: Path, tmp_path: Path
+    ) -> None:
+        """A fallback transcript provider is tracked on the metadata and in the DB."""
         from obsidian_ai_tools.models import VideoMetadata
+        from obsidian_ai_tools.observability import ObservabilityDB
         from obsidian_ai_tools.obsidian import write_note
+        from obsidian_ai_tools.providers.youtube import YouTubeProvider
 
-        metadata = VideoMetadata(
+        # The direct provider failed upstream, so supadata served the transcript.
+        fallback_metadata = VideoMetadata(
             title="Test Video",
             url="https://youtube.com/watch?v=fallback_test",
             transcript="Test transcript content for fallback scenario",
@@ -507,22 +469,27 @@ class TestYouTubeIngestEnhanced:
             provider_used="supadata",
         )
 
-        mock_llm_response = MagicMock()
-        mock_llm_response.choices = [
-            MagicMock(
-                message=MagicMock(
-                    content='{"title": "Fallback Test", "summary": "Summary", '
-                    '"key_points": ["Point"], "tags": ["test"]}'
-                )
-            )
-        ]
-        mock_llm_response.usage = MagicMock(prompt_tokens=50, completion_tokens=30, cost=0.001)
+        db = ObservabilityDB(tmp_path / "obs.db")
+        client = MagicMock()
+        client.get_video_metadata.return_value = fallback_metadata
 
-        with patch("obsidian_ai_tools.llm.OpenAI") as mock_openai:
-            mock_client = MagicMock()
-            mock_client.chat.completions.create.return_value = mock_llm_response
-            mock_openai.return_value = mock_client
+        with (
+            patch("obsidian_ai_tools.youtube.YouTubeClient", return_value=client),
+            patch("obsidian_ai_tools.providers.youtube.get_db", return_value=db),
+        ):
+            metadata = YouTubeProvider()._ingest(fallback_metadata.url)
 
+        # The name of this test is about provider tracking, so assert it.
+        assert metadata.provider_used == "supadata"
+        summary = db.get_provider_summary(days=1)
+        assert any(
+            row["provider"] == "youtube" and row["strategy"] == "primary" for row in summary
+        ), "Expected a 'youtube/primary' provider attempt to be recorded"
+
+        with patched_openai(
+            '{"title": "Fallback Test", "summary": "Summary", '
+            '"key_points": ["Point"], "tags": ["test"]}'
+        ):
             from obsidian_ai_tools.llm import generate_note
 
             note, _ = generate_note(
@@ -601,22 +568,9 @@ class TestIngestNoteGeneration:
             video_id="empty_tags",
         )
 
-        mock_llm_response = MagicMock()
-        mock_llm_response.choices = [
-            MagicMock(
-                message=MagicMock(
-                    content='{"title": "Empty Tags Test", "summary": "Summary", '
-                    '"key_points": [], "tags": []}'
-                )
-            )
-        ]
-        mock_llm_response.usage = MagicMock(prompt_tokens=50, completion_tokens=30, cost=0.001)
-
-        with patch("obsidian_ai_tools.llm.OpenAI") as mock_openai:
-            mock_client = MagicMock()
-            mock_client.chat.completions.create.return_value = mock_llm_response
-            mock_openai.return_value = mock_client
-
+        with patched_openai(
+            '{"title": "Empty Tags Test", "summary": "Summary", "key_points": [], "tags": []}'
+        ):
             from obsidian_ai_tools.llm import generate_note
 
             note, _ = generate_note(
@@ -645,22 +599,10 @@ class TestIngestNoteGeneration:
             video_id="special",
         )
 
-        mock_llm_response = MagicMock()
-        mock_llm_response.choices = [
-            MagicMock(
-                message=MagicMock(
-                    content='{"title": "Special Characters: A Test", "summary": "Summary", '
-                    '"key_points": ["Point with: colon"], "tags": ["test"]}'
-                )
-            )
-        ]
-        mock_llm_response.usage = MagicMock(prompt_tokens=50, completion_tokens=30, cost=0.001)
-
-        with patch("obsidian_ai_tools.llm.OpenAI") as mock_openai:
-            mock_client = MagicMock()
-            mock_client.chat.completions.create.return_value = mock_llm_response
-            mock_openai.return_value = mock_client
-
+        with patched_openai(
+            '{"title": "Special Characters: A Test", "summary": "Summary", '
+            '"key_points": ["Point with: colon"], "tags": ["test"]}'
+        ):
             from obsidian_ai_tools.llm import generate_note
 
             note, _ = generate_note(
@@ -702,22 +644,12 @@ class TestIngestEdgeCases:
             published_date=None,
         )
 
-        mock_llm_response = MagicMock()
-        mock_llm_response.choices = [
-            MagicMock(
-                message=MagicMock(
-                    content='{"title": "Short", "summary": "Short", '
-                    '"key_points": ["Short"], "tags": ["short"]}'
-                )
-            )
-        ]
-        mock_llm_response.usage = MagicMock(prompt_tokens=10, completion_tokens=10, cost=0.0001)
-
-        with patch("obsidian_ai_tools.llm.OpenAI") as mock_openai:
-            mock_client = MagicMock()
-            mock_client.chat.completions.create.return_value = mock_llm_response
-            mock_openai.return_value = mock_client
-
+        with patched_openai(
+            '{"title": "Short", "summary": "Short", "key_points": ["Short"], "tags": ["short"]}',
+            prompt_tokens=10,
+            completion_tokens=10,
+            cost=0.0001,
+        ):
             from obsidian_ai_tools.llm import generate_note
 
             note, _ = generate_note(
@@ -749,22 +681,13 @@ class TestIngestEdgeCases:
         tags = ["tag" + str(i) for i in range(15)]
         tags_json = json.dumps(tags)
 
-        mock_llm_response = MagicMock()
-        mock_llm_response.choices = [
-            MagicMock(
-                message=MagicMock(
-                    content='{"title": "Many Tags", "summary": "Summary", '
-                    f'"key_points": ["Point"], "tags": {tags_json}}}'
-                )
-            )
-        ]
-        mock_llm_response.usage = MagicMock(prompt_tokens=100, completion_tokens=100, cost=0.002)
-
-        with patch("obsidian_ai_tools.llm.OpenAI") as mock_openai:
-            mock_client = MagicMock()
-            mock_client.chat.completions.create.return_value = mock_llm_response
-            mock_openai.return_value = mock_client
-
+        with patched_openai(
+            '{"title": "Many Tags", "summary": "Summary", '
+            f'"key_points": ["Point"], "tags": {tags_json}}}',
+            prompt_tokens=100,
+            completion_tokens=100,
+            cost=0.002,
+        ):
             from obsidian_ai_tools.llm import generate_note
 
             note, _ = generate_note(

--- a/tests/test_ingestion_service.py
+++ b/tests/test_ingestion_service.py
@@ -32,6 +32,7 @@ def _settings(vault_path: Path) -> SimpleNamespace:
         obsidian_inbox_folder="inbox",
         llm_model="test-model",
         openrouter_api_key="test-key",
+        llm_base_url="https://openrouter.ai/api/v1",
         max_transcript_length=1234,
     )
 
@@ -111,6 +112,7 @@ def test_ingest_content_runs_shared_pipeline_and_emits_progress(tmp_path: Path) 
         existing_tags=None,
         max_content_length=1234,
         prompt_version="article_v1",
+        base_url="https://openrouter.ai/api/v1",
     )
     mock_write.assert_called_once_with(
         note=note, vault_path=tmp_path, inbox_folder="inbox", target_path=None

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -359,17 +359,19 @@ class TestFormatPreviewJson:
 
 
 class TestPreviewCommand:
-    """Integration tests for kai preview CLI command."""
+    """Integration tests for kai preview CLI command.
 
-    def test_preview_command_no_url(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    These tests need no environment setup of their own: the autouse
+    ``_isolate_settings`` fixture in conftest already exports a valid
+    ``OBSIDIAN_VAULT_PATH`` / ``OPENROUTER_API_KEY`` / ``LLM_MODEL`` trio, and
+    every test that touches the vault passes ``--vault`` explicitly.
+    """
+
+    def test_preview_command_no_url(self) -> None:
         """Test preview fails without URL."""
         from typer.testing import CliRunner
 
         from obsidian_ai_tools.cli import app
-
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path))
-        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
-        monkeypatch.setenv("LLM_MODEL", "test-model")
 
         runner = CliRunner()
         result = runner.invoke(app, ["preview"])
@@ -383,7 +385,6 @@ class TestPreviewCommand:
         mock_generate: MagicMock,
         tmp_path: Path,
         sample_preview: PreviewInfo,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test successful preview."""
         from typer.testing import CliRunner
@@ -391,10 +392,6 @@ class TestPreviewCommand:
         from obsidian_ai_tools.cli import app
 
         mock_generate.return_value = sample_preview
-
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path))
-        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
-        monkeypatch.setenv("LLM_MODEL", "test-model")
 
         runner = CliRunner()
         result = runner.invoke(app, ["preview", "https://example.com", "--vault", str(tmp_path)])
@@ -408,7 +405,6 @@ class TestPreviewCommand:
         mock_generate: MagicMock,
         tmp_path: Path,
         sample_preview: PreviewInfo,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test preview with JSON output."""
         from typer.testing import CliRunner
@@ -416,10 +412,6 @@ class TestPreviewCommand:
         from obsidian_ai_tools.cli import app
 
         mock_generate.return_value = sample_preview
-
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path))
-        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
-        monkeypatch.setenv("LLM_MODEL", "test-model")
 
         runner = CliRunner()
         result = runner.invoke(
@@ -434,7 +426,6 @@ class TestPreviewCommand:
         self,
         mock_generate: MagicMock,
         tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test preview with unsupported URL."""
         from typer.testing import CliRunner
@@ -442,10 +433,6 @@ class TestPreviewCommand:
         from obsidian_ai_tools.cli import app
 
         mock_generate.side_effect = UnsupportedURLError("Cannot determine source type")
-
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path))
-        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
-        monkeypatch.setenv("LLM_MODEL", "test-model")
 
         runner = CliRunner()
         result = runner.invoke(app, ["preview", "ftp://invalid.com", "--vault", str(tmp_path)])
@@ -461,7 +448,6 @@ class TestPreviewCommand:
         mock_generate: MagicMock,
         tmp_path: Path,
         sample_preview: PreviewInfo,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Batch mode should process valid stdin URLs and report total cost."""
         from typer.testing import CliRunner
@@ -469,9 +455,6 @@ class TestPreviewCommand:
         from obsidian_ai_tools.cli import app
 
         mock_generate.return_value = sample_preview
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path))
-        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
-        monkeypatch.setenv("LLM_MODEL", "test-model")
 
         result = CliRunner().invoke(
             app,
@@ -495,7 +478,6 @@ class TestPreviewCommand:
         mock_generate: MagicMock,
         tmp_path: Path,
         sample_preview: PreviewInfo,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Interactive preview should save the selected URL to the reading list."""
         from typer.testing import CliRunner
@@ -503,9 +485,6 @@ class TestPreviewCommand:
         from obsidian_ai_tools.cli import app
 
         mock_generate.return_value = sample_preview
-        monkeypatch.setenv("OBSIDIAN_VAULT_PATH", str(tmp_path))
-        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
-        monkeypatch.setenv("LLM_MODEL", "test-model")
 
         result = CliRunner().invoke(
             app,

--- a/tests/test_settings_isolation.py
+++ b/tests/test_settings_isolation.py
@@ -1,0 +1,68 @@
+"""Regression guards for test-suite settings hermeticity.
+
+These tests exist so that the leak mechanism described in
+docs/test-quality-review.md cannot come back silently:
+
+* the first guards a reintroduced import-time ``env_file`` binding on
+  ``Settings``;
+* the rest guard the autouse ``_isolate_settings`` fixture being removed or
+  weakened.
+
+Hard constraint: nothing here may render a credential value. Assertions use
+prefixes, lengths and booleans only, so a failure message is safe to paste
+into a log or a pull request.
+"""
+
+from pathlib import Path
+
+from obsidian_ai_tools.config import Settings, get_settings
+
+# Prefixes GitHub uses for its token formats. A settings object built inside a
+# test must never carry a value starting with any of these.
+_REAL_TOKEN_PREFIXES = ("github_pat_", "ghp_", "gho_", "ghu_", "ghs_", "ghr_")
+
+_PLACEHOLDER_MAX_LEN = 64
+
+
+def test_settings_model_config_has_no_frozen_env_file() -> None:
+    """Settings must not resolve a .env path at class-definition time.
+
+    A non-None value here means find_env_file() ran during import and froze an
+    absolute path onto the class, which is what made every fixture that tried
+    to redirect it inert.
+    """
+    assert Settings.model_config.get("env_file") is None
+
+
+def test_get_settings_never_carries_real_credentials(tmp_path: Path) -> None:
+    """The cached settings a test sees hold placeholders, not real config."""
+    settings = get_settings()
+
+    token = settings.github_token or ""
+    assert not token.startswith(_REAL_TOKEN_PREFIXES)
+    assert len(token) <= _PLACEHOLDER_MAX_LEN
+
+    assert settings.obsidian_vault_path.is_relative_to(tmp_path)
+    assert settings.cache_dir.is_relative_to(tmp_path)
+
+
+def test_direct_settings_construction_never_reads_the_real_env(tmp_path: Path) -> None:
+    """A bare Settings() picks up the fixture's env vars, not a real .env.
+
+    Settings loads no dotenv file of its own any more, so the only values it
+    can see are the ones the autouse fixture exported.
+    """
+    settings = Settings()  # type: ignore[call-arg]
+
+    token = settings.github_token or ""
+    assert not token.startswith(_REAL_TOKEN_PREFIXES)
+    assert len(token) <= _PLACEHOLDER_MAX_LEN
+
+    assert settings.obsidian_vault_path.is_relative_to(tmp_path)
+    for secret in (settings.openrouter_api_key, settings.supadata_key, settings.decodo_api_key):
+        assert secret is None or len(secret) <= _PLACEHOLDER_MAX_LEN
+
+
+def test_settings_cache_is_empty_at_test_start() -> None:
+    """No test inherits another test's Settings object."""
+    assert get_settings.cache_info().currsize == 0

--- a/tests/test_vault_usage.py
+++ b/tests/test_vault_usage.py
@@ -1,0 +1,186 @@
+"""Tests for the `kai usage` command in commands/vault.py.
+
+The command is a reporting shell over two DuckDB queries, so these tests seed a
+real ObservabilityDB in tmp_path and drive the command through CliRunner rather
+than mocking the DB layer - the same convention as
+tests/test_cli.py::test_rebuild_index_command and tests/test_observability.py.
+
+Note on counts: `usage` is wrapped in @track_command("usage"), which records its
+own invocation *after* the report is rendered, so it never appears in its own
+output.
+"""
+
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import call, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from obsidian_ai_tools.cli import app
+from obsidian_ai_tools.observability import ObservabilityDB, _set_db_for_test
+
+runner = CliRunner()
+
+# Every command name the report knows about when --all is passed.
+KNOWN_COMMANDS = [
+    "ingest",
+    "preview",
+    "rebuild-index",
+    "process-inbox",
+    "usage",
+    "search",
+    "serve:ingest",
+]
+
+
+@pytest.fixture
+def usage_db(tmp_path: Path) -> Iterator[ObservabilityDB]:
+    """A real, empty observability DB wired into get_db() for one test."""
+    db = ObservabilityDB(tmp_path / "usage_obs.duckdb")
+    _set_db_for_test(db)
+    yield db
+    _set_db_for_test(None)
+
+
+def _row_for(output: str, command: str) -> str:
+    """Return the report line for a command, or fail with the whole table."""
+    for line in output.splitlines():
+        if line.startswith(command + " ") or line == command:
+            return line
+    raise AssertionError(f"No row for {command!r} in:\n{output}")
+
+
+def test_usage_renders_the_invocation_table(usage_db: ObservabilityDB) -> None:
+    """Recorded invocations show up with call counts and a success rate."""
+    usage_db.record_invocation("ingest", "success", 1.2)
+    usage_db.record_invocation("ingest", "success", 0.8)
+    usage_db.record_invocation("ingest", "error", 0.5, error_type="ContentFetchError")
+    usage_db.record_invocation("search", "success", 0.3)
+
+    result = runner.invoke(app, ["usage"])
+
+    assert result.exit_code == 0
+    assert "Command usage — last 30 day(s)" in result.output
+    assert "No command invocations recorded yet." not in result.output
+
+    ingest_fields = _row_for(result.output, "ingest").split()
+    assert ingest_fields[:3] == ["ingest", "3", "67%"]
+
+    search_fields = _row_for(result.output, "search").split()
+    assert search_fields[:3] == ["search", "1", "100%"]
+
+
+def test_usage_days_option_narrows_both_queries(usage_db: ObservabilityDB) -> None:
+    """--days is forwarded to the invocation and provider summaries alike."""
+    usage_db.record_invocation("ingest", "success", 1.0)
+    usage_db.record_provider_attempt("web", "primary", "success", 0.4, url="https://example.com")
+
+    with (
+        patch.object(
+            usage_db, "get_invocation_summary", wraps=usage_db.get_invocation_summary
+        ) as invocation_summary,
+        patch.object(
+            usage_db, "get_provider_summary", wraps=usage_db.get_provider_summary
+        ) as provider_summary,
+    ):
+        result = runner.invoke(app, ["usage", "--days", "7"])
+
+    assert result.exit_code == 0
+    assert invocation_summary.call_args == call(days=7)
+    assert provider_summary.call_args == call(days=7)
+    assert "Command usage — last 7 day(s)" in result.output
+    assert "Provider attempts — last 7 day(s)" in result.output
+
+
+def test_usage_on_an_empty_db_points_at_the_all_flag(usage_db: ObservabilityDB) -> None:
+    """With nothing recorded and no --all, the guidance suggests --all."""
+    result = runner.invoke(app, ["usage"])
+
+    assert result.exit_code == 0
+    assert "No command invocations recorded yet." in result.output
+    assert "Run some commands, then check back — or use --all to see all commands." in result.output
+    assert "never used" not in result.output
+
+
+def test_usage_all_on_an_empty_db_lists_every_known_command(usage_db: ObservabilityDB) -> None:
+    """--all turns the empty report into a full never-run inventory."""
+    result = runner.invoke(app, ["usage", "--all"])
+
+    assert result.exit_code == 0
+    assert "No command invocations recorded yet." in result.output
+    assert "(All commands shown below have never been run)" in result.output
+
+    for command in KNOWN_COMMANDS:
+        fields = _row_for(result.output, command).split()
+        assert fields[:4] == [command, "0", "—", "never"]
+        assert "<- never used" in _row_for(result.output, command)
+
+
+def test_usage_all_keeps_recorded_commands_out_of_the_never_run_list(
+    usage_db: ObservabilityDB,
+) -> None:
+    """A command that has run is reported once, with its real numbers."""
+    usage_db.record_invocation("ingest", "success", 1.0)
+
+    result = runner.invoke(app, ["usage", "--all"])
+
+    assert result.exit_code == 0
+    ingest_rows = [line for line in result.output.splitlines() if line.startswith("ingest ")]
+    assert len(ingest_rows) == 1
+    assert ingest_rows[0].split()[:3] == ["ingest", "1", "100%"]
+    assert "never used" not in ingest_rows[0]
+    assert "<- never used" in _row_for(result.output, "search")
+
+
+def test_usage_renders_the_provider_table_with_a_fallback_rate(
+    usage_db: ObservabilityDB,
+) -> None:
+    """The fallback rate is a share of that provider's total attempts."""
+    for _ in range(3):
+        usage_db.record_provider_attempt(
+            "youtube", "primary", "success", 0.5, url="https://youtu.be/abc"
+        )
+    usage_db.record_provider_attempt(
+        "youtube", "fallback", "success", 0.9, url="https://youtu.be/abc"
+    )
+
+    result = runner.invoke(app, ["usage"])
+
+    assert result.exit_code == 0
+    assert "Provider attempts — last 30 day(s)" in result.output
+
+    primary = _row_for(result.output, "youtube    primary")
+    assert primary.split()[:4] == ["youtube", "primary", "3", "100%"]
+    assert "fallback rate" not in primary
+
+    fallback = _row_for(result.output, "youtube    fallback")
+    assert fallback.split()[:4] == ["youtube", "fallback", "1", "100%"]
+    # 1 fallback attempt out of 4 total youtube attempts.
+    assert "(25% fallback rate)" in fallback
+
+
+def test_usage_omits_the_provider_table_when_nothing_was_attempted(
+    usage_db: ObservabilityDB,
+) -> None:
+    """No provider attempts means no provider section at all."""
+    usage_db.record_invocation("search", "success", 0.2)
+
+    result = runner.invoke(app, ["usage"])
+
+    assert result.exit_code == 0
+    assert "Provider attempts" not in result.output
+
+
+def test_usage_exits_when_settings_cannot_be_loaded(usage_db: ObservabilityDB) -> None:
+    """get_settings() is a config-presence check; failing it stops the command."""
+    with patch(
+        "obsidian_ai_tools.commands.vault.get_settings",
+        side_effect=RuntimeError("Could not find .env file"),
+    ):
+        result = runner.invoke(app, ["usage"])
+
+    assert result.exit_code == 1
+    assert "❌ Configuration error" in result.stderr
+    assert "Could not find .env file" in result.stderr
+    assert "Command usage" not in result.output


### PR DESCRIPTION
[Artifacts](https://cloud.humanlayer.com/tasks/01a00bc3-1ed5-7a8f-bb9b-1dc14c948fd5/artifacts) | [Task](https://cloud.humanlayer.com/deep/tasks/01a00bc3-1ed5-7a8f-bb9b-1dc14c948fd5) | [PR Walkthrough (alpha)](https://cloud.humanlayer.com/artifacts/01a00e2c-ce71-72b4-96d7-a24c4ac4c5d8)

## What problems was I solving

One test in this suite printed a **real `github_pat_…` token** into the terminal when it failed, and it only failed on the developer's machine.

`tests/providers/test_github.py::test_github_provider_uses_token_header` passed in isolation and failed after `tests/test_cli.py`. The assertion failure rendered the actual `Authorization` header value, loaded from the developer's local `.env`. CI never saw it (no local `.env` there), so CI stayed green while `pre-commit run --all-files` was red on the dev machine, blocking local commits.

The cause was not the test. Three things stacked:

1. `Settings.model_config` called `find_env_file()` **in the class body**, so it ran at import time and froze the developer's real `.env` path onto the class for the whole process.
2. The autouse isolation fixture wrote a temp `.env` and `chdir`'d to it. The already-resolved absolute path ignored that completely, so the fixture reached nothing.
3. `get_settings()` is `@lru_cache`d, so whichever test called it first decided what every later test saw. `GitHubProvider._load_token()` reads `settings.github_token` before falling back to `os.getenv`, so the test's `monkeypatch.setenv` was outranked.

Shipped, a test process **cannot** load real credentials into a `Settings` object. Not "does not today" — cannot, with a regression test that fails loudly if either half of the fix is removed.

The same test-quality review named four more items, all closed here: `--maxfail=1` hid failures behind the first one, the network guard was opt-in with a single consumer, two modules sat under 45% coverage, and nine LLM mock blocks were copy-pasted.

**Measured outcome:** 383 tests (1 failing) → **410 passing**; branch coverage **82.77% → 85.68%**; `providers/youtube.py` 39.29% → **100%**; `commands/vault.py` 44.26% → **81.97%**; `config.py` 76.47% → **97.65%**.

> ⚠️ **The exposed PAT was revoked and replaced** with a fine-grained token scoped to public repositories, read-only, zero account permissions. Code changes stop the leak recurring; they do nothing about a token already printed.

## What user-facing changes did I ship

- [`src/obsidian_ai_tools/config.py`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-24775941da8a9c89fbb4d186f35776c4624b3db59838579bfb0958a30c51b2a4) - new `llm_base_url` setting (default `https://openrouter.ai/api/v1`), so an OpenAI-compatible local model such as LM Studio can be pointed at without editing source
- [`src/obsidian_ai_tools/llm.py`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-bcb3aa6c18e16a9037780c50a538f459a558f1b50ce00550cfd03a3bfb6b692b) - `generate_note()` takes `base_url` instead of hardcoding it; default keeps every existing caller identical
- [`scripts/test.sh`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-52afcc694c0ff8ff253441f42ff44d6b4734fe30ae9070f2ba07a668a10e7baa) - a failing run now reports **every** failure instead of aborting at the first
- [`.gitignore`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947) - ignore `.humanlayer/tasks/` (cloud-synced task artifacts, not source)

Everything else is test-suite behavior. No CLI command, output format, or config file changes shape.

## How I implemented it

Five phases, one commit each, each green on its own.

### Phase 1 — kill the mechanism, then prove it stays dead (`f3dcb3d`, `a58eb74`)

Neither half works alone: the `config.py` change without the fixture still reads the real `.env`, and the fixture without the `config.py` change is still bypassed by the frozen path.

- [`src/obsidian_ai_tools/config.py`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-24775941da8a9c89fbb4d186f35776c4624b3db59838579bfb0958a30c51b2a4R32) - `env_file` dropped from the class-body `SettingsConfigDict`; `get_settings()` passes the per-call result via the documented `Settings(_env_file=env_file)` override. Both `RuntimeError` branches keep their exact text. A `NOTE` comment explains why `env_file` is deliberately absent, so nobody re-adds it.
  - Side effect worth knowing: a direct `Settings(...)` call now loads **no** dotenv file at all. Strictly more hermetic, and every existing call site already passes its fields explicitly.
- [`tests/conftest.py`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128) - `mock_settings_env` → `_isolate_settings`, with **two independent layers**. Layer 1 patches `obsidian_ai_tools.config.find_env_file` at a `tmp_path` `.env`. Layer 2 exports the same keys as env vars, which outrank dotenv values in pydantic-settings' precedence, covering bare `Settings(...)` too. `get_settings.cache_clear()` on setup *and* teardown.
  - Key set = the old 12 **plus every remaining secret-bearing field**: `GITHUB_TOKEN`, `YOUTUBE_API_KEY`, `DECODO_API_KEY`, `SUPADATA_KEY`. Without those four, layer 2 alone still lets real values through.
  - `os.chdir` dropped (nothing consumed it). Because `CACHE_DIR` defaults to the relative `.cache`, the fixture must set it, or a cache write lands in the repo root once the chdir is gone.
- [`tests/providers/test_github.py`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-166ff3dcb4f82431788ed98cf6d7517269f5b4c415431b12d85ad585a518eae4R214) - the hand-written `patch("...github.get_settings", side_effect=RuntimeError(...))` block is gone. The placeholder `test-github-token` is truthy, so the test sets its value through settings: `monkeypatch.setenv` plus `get_settings.cache_clear()`.
- [`tests/test_settings_isolation.py`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-7c2b47c1f9c4c27f1ef55983f7a37c6a9e19556c9f96eed79bac7c9c7d868869) **(new)** - four guards. `test_settings_model_config_has_no_frozen_env_file` catches a reintroduced import-time binding; the other three catch the fixture being removed or weakened. **Hard constraint honored throughout: assertions use prefixes, lengths and booleans only**, so a failure message is safe to paste into a log or a PR.

### Phase 2 — rewrite the cache tests that caused the incident (`a58eb74`)

`TestGetSettingsCache` was the only end-to-end exercise of `get_settings()`, and both its tests were gated on `pytest.skip` conditions that never fired while rebuilding `Settings` from the real `.env`. That is the exact class of test that poisoned the GitHub token test.

- [`tests/test_config.py`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-da24b355349b53e4c8047034767d008e4c2ce9ea6c8933a3acd50d0828f00528) - dead skip guards dropped; `test_get_settings_reads_the_file_find_env_file_reports` writes two different `.env` files and asserts values change when `find_env_file` is repointed (the direct regression test for the `_env_file` change); new `TestGetSettingsErrors` covers both `RuntimeError` branches plus non-validation errors propagating unchanged; new `TestFindEnvFile` covers the real upward walk, nearest-wins, the `~/.kai/.env` fallback, and not-found.
  - **Gotcha:** the autouse fixture patches `obsidian_ai_tools.config.find_env_file`. A module-level `from ... import find_env_file` binds the *original* at collection time, before fixtures run, so `TestFindEnvFile` gets the real implementation. A function-body import would have gotten the patched one.
  - One line stays uncovered on purpose: `raise ValueError("Provider order cannot be empty")` is unreachable, since `"".split(",")` returns `[""]` and the invalid-name check rejects that first.

### Phase 3 — honest failure reporting and a real network guard (`cc593ab`)

- [`pyproject.toml`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) and [`scripts/test.sh`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-52afcc694c0ff8ff253441f42ff44d6b4734fe30ae9070f2ba07a668a10e7baa) - `--maxfail=1` removed from **both** places it was set. It was passed twice, so changing one site alone would have changed nothing observable.
- [`tests/conftest.py`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128) - `disable_network_calls` flipped to `autouse=True`. The docstring now **states the scope limit plainly**: it replaces `requests.get`/`requests.post` and nothing else. It does *not* cover `httpx` (which the OpenAI client uses), `urllib`, or raw sockets. Module-boundary patches keep working, because `providers.web.requests` is the same module object the fixture patched.
- [`tests/test_fixtures.py`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-03a30f8601957b63a8af89a36235b4d48831aa838d75e8647f53b9035d0adcd8) - seven of nine tests deleted; they asserted that `MagicMock` returns what it was told to return. `test_disable_network_calls_fixture` no longer takes the fixture as a parameter, which is what makes it an assertion about the guard rather than about a fixture it pulled in itself. Coverage was unchanged by the deletions, confirming the seven covered no production line.
- Fixture pruning: `mock_requests_get`, `mock_requests_post`, `mock_openrouter_response`, `mock_youtube_transcript` had no consumer left and were deleted. `mock_pdf_content` and `mock_supadata_response` are still consumed and stay.

### Phase 4 — close the two worst coverage holes (`af9c023`)

Both modules had no dedicated test file, and both got easier to test after Phase 1: `usage` calls `get_settings()` as a config-presence check, which now succeeds with test values.

- [`tests/providers/test_youtube_provider.py`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-bbc1ca1c12127c22e3e4861b5eeb6591e9f5266f9138bbe8ff68783d16780a14) **(new, 8 functions / 16 cases)** - `validate()` for `youtube.com`, `youtu.be` and a non-match; success records `record_provider_attempt("youtube", "primary", "success", …)`; failure records `"failure"` with `type(exc).__name__` **and re-raises**; `provider_order` plucked from `**kwargs` and forwarded, including the `None` case; a `get_db()` that raises does not change the ingest outcome on either path.
  - **Patch targets differ by import style:** `YouTubeClient` is a deferred import, so the defining module is patched (`obsidian_ai_tools.youtube.YouTubeClient`); `get_db` is module-level, so it is patched at the use site (`obsidian_ai_tools.providers.youtube.get_db`).
- [`tests/test_vault_usage.py`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-c6b75bc73fdc34865f778ccc5bf4987616e2fb2e643884da21eb42293997da84) **(new, 8 tests)** - covers the whole previously-unreached `commands/vault.py:210-281`. Seeds a real `ObservabilityDB` via `_set_db_for_test` and drives `CliRunner`, following the existing convention rather than mocking the DB layer. Includes the **fallback-rate arithmetic** at 257-281, which no test previously touched, and the `get_settings`-raises exit-1 path.

### Phase 5 — one LLM mock helper, one honest assertion (`22b226a`)

- [`tests/conftest.py`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128) - new `patched_openai(content, *, prompt_tokens=50, completion_tokens=30, cost=0.001)` context manager. Only the JSON payload and usage numbers varied between call sites; the ~10-line scaffold was byte-identical. Module-level in `conftest.py`, imported as `from conftest import patched_openai` — that resolves because pytest's default `prepend` import mode puts `tests/` (no `__init__.py`) on `sys.path`. Verified in isolation, in a full run, and under the `pytest-fast` pre-commit hook.
- [`tests/test_ingest.py`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-520ed8d68cc1665b0386c5004701d288d22fa9f4e7f8aa8b4e2ea52605a06bfd) - **nine** call sites converted (the outline said 8; there were 9). Defaults match 5 verbatim; the other 4 pass their numbers explicitly. All nine were diffed against the pre-refactor file to confirm payloads and numbers survived.
  - `test_youtube_ingest_provider_fallback_logging` was named for provider tracking but only asserted a file exists. It now drives the real `YouTubeProvider._ingest` with a client returning `provider_used="supadata"` (the fallback case its name promises) and asserts both halves: the value survives the provider layer, and a seeded `ObservabilityDB` records the `youtube`/`primary` attempt.
- [`tests/test_preview.py`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-6c5490a919857c4e185c22205ebe5a01f99718b7f59896fce6080903907b8054) - the six repeated `monkeypatch.setenv` trios were **deleted, not factored into a fixture**. Phase 1's autouse fixture already exports all three values, five of the six tests pass `--vault` explicitly, and the sixth exits before the vault is used. The reason is recorded in the `TestPreviewCommand` docstring.

### Riding along — configurable LLM base URL (`d30cd15`)

The one production behavior change not about tests. It landed on this branch before the hermeticity work and is included here rather than split out: [`llm.py`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-bcb3aa6c18e16a9037780c50a538f459a558f1b50ce00550cfd03a3bfb6b692b) takes `base_url`, [`config.py`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-24775941da8a9c89fbb4d186f35776c4624b3db59838579bfb0958a30c51b2a4) adds `llm_base_url`, [`ingestion.py`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-0212f3e31e3c9eeae71d7771eb9d830dbc49a3ddf5d6bdf152404c25c1bec82a) wires it through, and [`test_ingestion_service.py`](https://github.com/larshansen1/obsidian-ai-tools/pull/47/files#diff-b60565665d84fdf3150bd38258232436c5520fd329519266bd877b0b22b514f0) asserts it reaches `generate_note`.

## Deviations from the plan

Compared against `.humanlayer/tasks/fix-test-hermeticity-and-secret-leak-issues/04-structure-outline-test-hermeticity.md`.

### Implemented as planned

- Phase 1: `config.py` no longer freezes `env_file`; `get_settings()` uses `Settings(_env_file=env_file)`. `_isolate_settings` replaces `mock_settings_env` with both layers, the expanded 16-key set, cache clears on both ends, and no `os.chdir`. `test_github.py`'s hand-written patch removed. `test_settings_isolation.py` added, never rendering a token value.
- Phase 2: `pytest.skip` guards dropped; identity, cache-clear-distinctness, and repointed-`find_env_file` regression tests added; both `RuntimeError` branches and the real `find_env_file()` walk covered, using the planned module-level import to dodge the autouse patch.
- Phase 3: `--maxfail=1` removed from `pyproject.toml` and both `scripts/test.sh` branches; `disable_network_calls` autouse with the documented scope note; `test_fixtures.py` pruned to two; the four unconsumed fixtures deleted and the two still-consumed ones kept.
- Phase 4: both new test files cover exactly what was specified, including the patch-target distinction and the real-`ObservabilityDB` convention.
- Phase 5: `patched_openai` placed and imported as planned; all nine call sites converted with payloads and numbers preserved; the six `test_preview.py` sites deleted per the plan's own contingency; the weak assertion fixed to assert both halves of provider tracking.
- Both Open Questions left genuinely open, not silently resolved.

### Deviations/surprises

- **`TestGetSettingsErrors` is a separate class**, not folded into the `TestGetSettingsCache` rewrite as the plan's diff sketch showed. Same coverage, cleaner separation once the class grew.
- **`TestFindEnvFile` gained `test_nearest_env_file_wins`**, not in the plan's bullet list (which named only current-directory, upward-walk, and home-fallback). Reasonable extra case for the walk logic.
- **The plan's own Phase-2 log says "20 passed, up from 13"**; `tests/test_config.py` actually went from 11 tests on `main` to 20. Discrepancy in the plan's logged number, not in the implementation — the final 20 is correct.

### Additions not in plan

- **`d30cd15` (`llm_base_url`)** is in `main...HEAD`. The plan branches from it and references it as prior work, so it belongs to no phase, but a reviewer diffing against `main` will see `llm.py`, `ingestion.py` and `test_ingestion_service.py` change for an unrelated feature.
- **`.gitignore` gets `.humanlayer/tasks/`**, added in the Phase 1 commit. Housekeeping, unrelated to hermeticity.

### Items planned but not implemented

None. Every phase is complete and confirmed against the diff. The two Open Questions (`time.sleep(0.1)` in `tests/test_indexer.py:235,258`; the `.gitleaks.toml` `(^|/)tests/` allowlist) were never assigned to a phase, so their absence is expected rather than a missed item.

> **Worth a follow-up decision:** that `.gitleaks.toml` allowlist exempts every test file at any depth, so a credential written into a test would not be flagged — and `tests/test_settings_isolation.py` is exactly the kind of file where that matters.

## How to verify it

### Worktree setup

```bash
git fetch origin
git worktree add ../obsidian-ai-tools-review fix/test-hermeticity
cd ../obsidian-ai-tools-review
```

### Manual Testing

- [ ] **The check that matters.** Rename your local `.env` away, run `./scripts/test.sh -q`, confirm the suite is still green with the same count. This is what distinguishes "does not read the real `.env` today" from "cannot". Restore it afterwards.
- [ ] Confirm no secret can appear in output: `./scripts/test.sh -q 2>&1 | grep -c "github_pat_"` returns `0` (it prints a count, never a value).
- [ ] Confirm the original failing order is green: `./scripts/test.sh tests/test_cli.py tests/providers/test_github.py -q`.
- [ ] Confirm production config still works from a subdirectory: `cd src && kai search <anything>` — the per-call `find_env_file()` upward walk must still find the real `.env`.
- [ ] Confirm the network guard fires. Add a throwaway test calling `requests.get("https://example.com")`; it must raise `RuntimeError("Attempted real network call…")`. Delete it after.
- [ ] Run `kai usage` and `kai usage --all` against the real vault DB and confirm the output matches what the new tests assert — the fallback-rate column is arithmetic no test previously touched.

### Automated Tests

```bash
./scripts/test.sh -q                  # 410 passed
COVERAGE=1 ./scripts/test.sh -q       # TOTAL 85.68% (floor 80%)
./scripts/test.sh -m slow -q          # 4 passed under the autouse network guard
.venv/bin/ruff check . && .venv/bin/ruff format --check .
.venv/bin/python -m mypy --config-file mypy.ini src
pre-commit run --all-files
```

**Known baselines, so you can tell signal from noise:**

- `mypy` reports 3 pre-existing `arg-type` errors in `providers/pdf.py:311` and `providers/web.py:231`. Verified unchanged by stashing the `config.py` change.
- `ruff format --check` reports 3 pre-existing markdown files (`SEARCH_ALGORITHMS.md`, `docs/features-napkin-inspired.md`, `docs/test-quality-review.md`). All 94 Python files are formatted.

## Description for the changelog

Test suite can no longer read the developer's real `.env` — closes an order-dependent failure that printed a live GitHub PAT — plus autouse network blocking, honest multi-failure reporting, and coverage up 82.77% → 85.68%.
