### PR TITLE
docs(adr): defer NoteSource adapter interface (issue #14)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -126,6 +126,8 @@ All writes are best-effort — a DB failure never blocks the operation. The sing
 
 ## Key design decisions
 
+Numbered architecture decision records live in [`docs/adr/`](docs/adr/). The decisions below predate that convention.
+
 **Single config source.** `config.py: get_settings()` is `@lru_cache`; all modules import it. Settings are validated by Pydantic at startup with explicit error messages.
 
 **Explicit error types.** Each module raises its own typed exceptions (`ContentFetchError`, `NoteGenerationStageError`, `VaultWriteError`, …). The CLI catches these and maps them to user-facing messages; the HTTP server maps them to HTTP status codes.
@@ -156,5 +158,4 @@ See `DEVELOPMENT.md` for the full quality gate reference and `CLI_COMMANDS.md` f
 |-------|-------|
 | [#31](https://github.com/larshansen1/obsidian-ai-tools/issues/31) | Consolidate duplicate rate-limiter and fallback pattern across `web.py` / `pdf.py` |
 | [#32](https://github.com/larshansen1/obsidian-ai-tools/issues/32) | Delete `api_contracts.py` (0 callers) or wire its validators at call sites |
-| [#14](https://github.com/larshansen1/obsidian-ai-tools/issues/14) | Provider plugin/adapter structure — blocked on usage review [#29](https://github.com/larshansen1/obsidian-ai-tools/issues/29) |
 | [#30](https://github.com/larshansen1/obsidian-ai-tools/issues/30) | This document update (closes on merge of this commit) |

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The note lands in your vault's inbox folder with frontmatter (`title`, `tags`, `
 
 YouTube ingestion can use free direct transcript fetching. Supadata and Decodo keys are optional fallbacks.
 
+The vault does not have to be an Obsidian vault: `OBSIDIAN_VAULT_PATH` can point at any folder of markdown files. Obsidian-specific extras (the clickable `obsidian://open` link, `[[wikilink]]` backlink boosting in search) degrade gracefully when the folder is not managed by Obsidian. See [`docs/adr/0001-defer-note-source-adapter.md`](docs/adr/0001-defer-note-source-adapter.md).
+
 ## Installation
 
 ```bash

--- a/docs/adr/0001-defer-note-source-adapter.md
+++ b/docs/adr/0001-defer-note-source-adapter.md
@@ -1,0 +1,36 @@
+# 0001: Defer NoteSource adapter interface
+
+Status: accepted (2026-08-17)
+
+## Context
+
+Issue [#14](https://github.com/larshansen1/obsidian-ai-tools/issues/14) proposed a `NoteSource` plugin/adapter interface so note storages other than Obsidian (Notion export, plain markdown folders, Logseq) could be supported without forking core logic. The issue was blocked on the usage review in [#29](https://github.com/larshansen1/obsidian-ai-tools/issues/29), which closed 2026-07-01 without pruning providers.
+
+Evaluation against the codebase as of commit `d30cd15`:
+
+- **Usage is a single pipeline against a single vault.** The #29 telemetry (28 days) shows the real product is `serve:ingest` → inbox → `process-inbox`. There is zero demand for a second note source — no user request, no contributor proposal.
+- **Obsidian coupling is thin and localized.** Only three behaviors are genuinely Obsidian-specific: the `obsidian://open` URL built in `obsidian.py`, the `[[wikilink]]` regex in `wikilinks.py` (feeds search backlink boosting), and `.obsidian` directory skip-lists. Everything else — frontmatter schema, `inbox` folder, `.kai` metadata directory, `folder_rules.json` — is this tool's own markdown-on-disk convention, which any plain folder satisfies.
+- **A "plain markdown folder" source already works today.** Nothing validates that `OBSIDIAN_VAULT_PATH` points at a real Obsidian vault; pointing it at any markdown folder works, with the Obsidian-specific extras degrading gracefully (the `obsidian://` link is simply less useful).
+- **The testability motivation is already satisfied.** Every vault-touching test builds a throwaway directory under pytest's `tmp_path`; no test requires Obsidian.
+- **The refactor would be large and speculative.** Vault I/O today is 19 direct `pathlib` call sites spread across 7 modules with no shared filesystem layer. Migrating all of them behind an interface designed against exactly one implementation risks producing the wrong abstraction (rule of three: we have one).
+
+## Decision
+
+Do not introduce a `NoteSource` plugin/adapter interface now.
+
+## Consequences
+
+- Vault I/O stays as direct `pathlib` calls against a `vault_path` root threaded in from settings, CLI flag, or HTTP request body.
+- The known vault-side debts remain and are tracked separately: two independent frontmatter parsers (`indexer.py` via python-frontmatter vs. the hand-rolled scanner in `dedup.py`), frontmatter written via f-string instead of a YAML library, and the observability singleton reading `settings.obsidian_vault_path` directly (bypassing per-request vault overrides). A follow-up issue proposes consolidating vault I/O into one internal `VaultStore` seam — an internal refactor, not a plugin interface — which would also make a future adapter cheap.
+- Issue #14 is closed with this record.
+
+## Revisit triggers
+
+Any one of these reopens the question:
+
+1. A concrete second source is actually requested or attempted (e.g. a real Notion export or Logseq graph), not hypothetically.
+2. A second Obsidian-specific behavior needs to spread beyond its current localized spot.
+3. The vault I/O consolidation follow-up lands, making the adapter's remaining cost small.
+4. An external contributor proposes an adapter PR.
+
+If revisited, the interface should mirror the existing provider pattern (`providers/base.py`: small ABC surface, shared behavior in the base, ordered factory) rather than invent a second style.


### PR DESCRIPTION
## Summary

- Add `docs/adr/0001-defer-note-source-adapter.md`: record the issue #14 decision to **not** introduce a `NoteSource` plugin/adapter interface now, with explicit revisit triggers.
- Point `ARCHITECTURE.md` at the new `docs/adr/` convention and remove the resolved #14 row from open architecture work.
- Document in README that `OBSIDIAN_VAULT_PATH` can point at any markdown folder (Obsidian-specific extras degrade gracefully).

## Why defer

- #29 telemetry: single pipeline (`serve:ingest` → inbox → `process-inbox`), single vault, zero second-source demand.
- Only 3 genuinely Obsidian-specific behaviors, all localized; plain markdown folders already work.
- All vault tests already run against `tmp_path`; the testability benefit is already banked.
- Full adapter would migrate 19 direct vault I/O call sites across 7 modules against a single implementation.

Refs #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)